### PR TITLE
Align Polymer version on ^0.9.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/PolymerElements/neon-animation",
   "ignore": [],
   "dependencies": {
-    "polymer": "Polymer/polymer#v0.9.0-rc.1",
+    "polymer": "Polymer/polymer#^0.9.0",
     "iron-meta": "PolymerElements/iron-meta#^0.9.0",
     "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^0.9.0",
     "iron-selector": "PolymerElements/iron-selector#^0.9.0",
@@ -30,11 +30,11 @@
   "devDependencies": {
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^0.9.0",
     "paper-styles": "PolymerElements/paper-styles#^0.9.0",
-    "paper-toolbar": "PolymerElements/paper-toolbar#~0.9.0",
+    "paper-toolbar": "PolymerElements/paper-toolbar#^0.9.0",
     "iron-component-page": "PolymerElements/iron-component-page#^0.9.0",
     "test-fixture": "PolymerElements/test-fixture#^0.9.0",
     "web-component-tester": "*",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.6.0",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
     "paper-item": "PolymerElements/paper-item#^0.9.0",
     "iron-icon": "PolymerElements/iron-icon#^0.9.0",
     "iron-icons": "PolymerElements/iron-icons#^0.9.0",


### PR DESCRIPTION
We have an issue with neon-animation depending on Polymer `v0.9.0-rc.1`.
Since our application depends on Polymer `^0.9.0` (which is for now `0.9.2`) and we use [paper-dialog](https://github.com/PolymerElements/paper-dialog/) which depends on neon-animation#^0.9.2, we have some conflicts such as:

    Unable to find a suitable version for webcomponentsjs, please choose one:
      1) webcomponentsjs#^0.6.0 which resolved to 0.6.2 and is required by polymer#0.9.0-rc.1
      2) webcomponentsjs#^0.7.1 which resolved to 0.7.1 and is required by polymer#0.9.2

The retrieved version of Polymer is also `0.9.0-rc.1` for all dependencies.

As Polymer `0.9.2` is now released, it makes sense to align neon-animation to polymer#^0.9.0 (as all other packages).

Thanks.