### PR TITLE
Restrict resize notifications to a destination page on neon-animated-pages

### DIFF
--- a/neon-animated-pages.html
+++ b/neon-animated-pages.html
@@ -191,7 +191,7 @@ animations to be run when switching to or switching out of the page.
           node.classList && node.classList.remove('neon-animating');
         }
       }
-      this.async(this.notifyResize);
+      this.async(this._notifyPageResize);
     },
 
     _onNeonAnimationFinish: function(event) {
@@ -200,6 +200,14 @@ animations to be run when switching to or switching out of the page.
         return;
       }
       this._completeSelectedChanged(event.detail.fromPage, event.detail.toPage);
+    },
+
+    _notifyPageResize: function() {
+      var selectedPage = this.selectedItem;
+      this.resizerShouldNotify = function(element) {
+        return element == selectedPage;
+      }
+      this.notifyResize();
     }
 
   })

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<!--
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>neon-animation tests</title>
+  <script src="../../web-component-tester/browser.js"></script>
+</head>
+<body>
+  <script>
+    WCT.loadSuites([
+      'neon-animated-pages.html'
+    ]);
+  </script>
+</body>
+</html>

--- a/test/neon-animated-pages.html
+++ b/test/neon-animated-pages.html
@@ -21,10 +21,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
-  <script src="../../iron-test-helpers/test-helpers.js"></script>
-
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../neon-animated-pages.html">
+  <link rel="import" href="test-resizable-pages.html">
 
 </head>
 <body>
@@ -36,8 +35,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="notify-resize">
+    <template>
+      <neon-animated-pages>
+        <a-resizable-page></a-resizable-page>
+        <b-resizable-page></b-resizable-page>
+        <c-resizable-page></c-resizable-page>
+      </neon-animated-pages>
+    </template>
+  </test-fixture>
+
   <script>
     suite('basic', function() {
+    });
+    suite('notify-resize', function() {
+      test('only a destination page recieves a resize event', function(done) {
+        var animatedPages = fixture('notify-resize');
+        var resizables = Polymer.dom(animatedPages).children;
+        var recieves = {};
+        resizables.forEach(function(page) {
+          page.addEventListener('iron-resize', function(event) {
+            var pageName = event.currentTarget.tagName;
+            recieves[pageName] = pageName in recieves ? recieves[pageName] + 1 : 1;
+          });
+        });
+        animatedPages.selected = 2;
+        setTimeout(function() {
+          assert.deepEqual(recieves, {
+            'C-RESIZABLE-PAGE': 1
+          });
+          done();
+        }, 50);
+      });
     });
   </script>
 

--- a/test/neon-animated-pages.html
+++ b/test/neon-animated-pages.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<!--
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+
+  <title>neon-animated-pages tests</title>
+
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+  <script src="../../iron-test-helpers/test-helpers.js"></script>
+
+  <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="../neon-animated-pages.html">
+
+</head>
+<body>
+
+  <test-fixture id="basic">
+    <template>
+      <neon-animated-pages>
+      </neon-animated-pages>
+    </template>
+  </test-fixture>
+
+  <script>
+    suite('basic', function() {
+    });
+  </script>
+
+</body>
+</html>

--- a/test/test-resizable-pages.html
+++ b/test/test-resizable-pages.html
@@ -1,0 +1,59 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../paper-styles/paper-styles.html">
+<link rel="import" href="../neon-shared-element-animatable-behavior.html">
+<link rel="import" href="../../iron-resizable-behavior/iron-resizable-behavior.html">
+
+<dom-module id="a-resizable-page">
+  <template>
+  </template>
+</dom-module>
+
+<dom-module id="b-resizable-page">
+  <template>
+  </template>
+</dom-module>
+
+<dom-module id="c-resizable-page">
+  <template>
+  </template>
+</dom-module>
+
+<script>
+(function() {
+
+  Polymer({
+    is: 'a-resizable-page',
+    behaviors: [
+      Polymer.NeonSharedElementAnimatableBehavior,
+      Polymer.IronResizableBehavior
+    ]
+  });
+
+  Polymer({
+    is: 'b-resizable-page',
+    behaviors: [
+      Polymer.NeonSharedElementAnimatableBehavior,
+      Polymer.IronResizableBehavior
+    ]
+  });
+
+  Polymer({
+    is: 'c-resizable-page',
+    behaviors: [
+      Polymer.NeonSharedElementAnimatableBehavior,
+      Polymer.IronResizableBehavior
+    ]
+  });
+
+})();
+</script>


### PR DESCRIPTION
`neon-animated-pages` notifies all pages of resize events when a selection is completed. This PR restricts the notifications to a destination page.