### PR TITLE
Fix scale up animation.

### DIFF
--- a/animations/scale-up-animation.html
+++ b/animations/scale-up-animation.html
@@ -45,7 +45,7 @@ Configuration:
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
       }
 
-      var scaleProperty = 'scale(1, 1)';
+      var scaleProperty = 'scale(0, 0)';
       if (config.axis === 'x') {
         scaleProperty = 'scale(0, 1)';
       } else if (config.axis === 'y') {


### PR DESCRIPTION
The scale up animation wasn't working because the `transform` was : `scale(1,1)` to `scale(1,1)` if no axis was configured. The `transform` should be `scale(0, 0)` to `scale(1, 1)`