### PR TITLE
Fix https://github.com/PolymerElements/neon-animation/issues/62.

### DIFF
--- a/neon-animated-pages.html
+++ b/neon-animated-pages.html
@@ -210,7 +210,7 @@ animations to be run when switching to or switching out of the page.
     },
 
     _notifyPageResize: function() {
-      var selectedPage = this.selectedItem;
+      var selectedPage = this.selectedItem || this._valueToItem(this.selected);
       this.resizerShouldNotify = function(element) {
         return element == selectedPage;
       }


### PR DESCRIPTION
Fix https://github.com/PolymerElements/neon-animation/issues/62.

If `selectedItem` is unknow when `_notifyPageResize` is called, we try to resolve it.