### PR TITLE
added warning 

### DIFF
--- a/neon-animatable-behavior.html
+++ b/neon-animatable-behavior.html
@@ -95,6 +95,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return;
       }
 
+      if(this.animationConfig.value && typeof this.animationConfig.value === 'function')
+      {
+      	this._warn(this._logf('playAnimation', "Please put 'animationConfig' inside of your components 'properties' object instead of outside of it."));
+      	return;
+      }
+
       // type is optional
       var thisConfig;
       if (type) {


### PR DESCRIPTION
Added a warning for `playAnimation` in case you accidentally put the `animationConfig` outside of the properties object. This took me a day to figure out, so hoping this warning saves other developers time.