### PR TITLE
added warning 

### DIFF
--- a/neon-animatable-behavior.html
+++ b/neon-animatable-behavior.html
@@ -95,6 +95,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return;
       }
 
+      if(this.animationConfig.value && typeof this.animationConfig.value === 'function') {
+      	this._warn(this._logf('playAnimation', "Please put 'animationConfig' inside of your components 'properties' object instead of outside of it."));
+      	return;
+      }
+
       // type is optional
       var thisConfig;
       if (type) {


### PR DESCRIPTION
Added a warning for `playAnimation` in case you accidentally put the `animationConfig` outside of the properties object. This took me a day to figure out, so hoping this warning saves other developers time.

Example:
![screen shot 2015-09-17 at 9 28 51 am](https://cloud.githubusercontent.com/assets/424737/9934344/934480d6-5d1e-11e5-9a0a-f9abc84f2997.png)

