### PR TITLE
Add animations to slide from top and to slide from bottom

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,12 +272,14 @@ The new page will slide in from the right, and the old page slide away to the le
 
 Single element animations:
 
- * `fade-in-animation` Animates opacity from `0` to `1`.
- * `fade-out-animation` Animates opacity from `1` to `0`.
- * `scale-down-animation` Animates transform from `scale(1)` to `scale(0)`.
- * `scale-up-animation` Animates transform from `scale(0)` to `scale(1)`.
- * `slide-down-animation` Animates transform from `translateY(-100%)` to `none`.
- * `slide-up-animation` Animates transform from `none` to `translateY(-100%)`.
+ * `fade-in-animation` Animates opacity from `0` to `1`;
+ * `fade-out-animation` Animates opacity from `1` to `0`;
+ * `scale-down-animation` Animates transform from `scale(1)` to `scale(0)`;
+ * `scale-up-animation` Animates transform from `scale(0)` to `scale(1)`;
+ * `slide-down-animation` Animates transform from `translateY(-100%)` to `none`;
+ * `slide-up-animation` Animates transform from `none` to `translateY(-100%)`;
+ * `slide-from-top-animation` Animates transform from `translateY(-100%)` to `none`;
+ * `slide-from-bottom-animation` Animates transform from `translateY(100%)` to `none`;
  * `slide-left-animation` Animates transform from `none` to `translateX(-100%)`;
  * `slide-right-animation` Animates transform from `none` to `translateX(100%)`;
  * `slide-from-left-animation` Animates transform from `translateX(-100%)` to `none`;

--- a/animations/slide-from-bottom-animation.html
+++ b/animations/slide-from-bottom-animation.html
@@ -13,13 +13,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../web-animations.html">
 
 <!--
-`<slide-down-animation>` animates the transform of an element from `translateY(-100%)` to `none`.
+`<slide-from-bottom-animation>` animates the transform of an element from `none` to `translateY(100%)`.
 The `transformOrigin` defaults to `50% 0`.
 
 Configuration:
 ```
 {
-  name: 'slide-down-animation',
+  name: 'slide-from-bottom-animation',
   node: <node>,
   transformOrigin: <transform-origin>,
   timing: <animation-timing>
@@ -31,7 +31,7 @@ Configuration:
 
   Polymer({
 
-    is: 'slide-down-animation',
+    is: 'slide-from-bottom-animation',
 
     behaviors: [
       Polymer.NeonAnimationBehavior
@@ -47,8 +47,8 @@ Configuration:
       }
 
       this._effect = new KeyframeEffect(node, [
-        {'transform': 'translateY(0%)'},
-        {'transform': 'translateY(100%)'}
+        {'transform': 'translateY(100%)'},
+        {'transform': 'translateY(0)'}
       ], this.timingFromConfig(config));
 
       return this._effect;

--- a/animations/slide-from-top-animation.html
+++ b/animations/slide-from-top-animation.html
@@ -13,13 +13,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../web-animations.html">
 
 <!--
-`<slide-down-animation>` animates the transform of an element from `translateY(-100%)` to `none`.
-The `transformOrigin` defaults to `50% 0`.
+`<slide-from-top-animation>` animates the transform of an element from `translateY(-100%)` to
+`none`. The `transformOrigin` defaults to `50% 0`.
 
 Configuration:
 ```
 {
-  name: 'slide-down-animation',
+  name: 'slide-from-top-animation',
   node: <node>,
   transformOrigin: <transform-origin>,
   timing: <animation-timing>
@@ -31,7 +31,7 @@ Configuration:
 
   Polymer({
 
-    is: 'slide-down-animation',
+    is: 'slide-from-top-animation',
 
     behaviors: [
       Polymer.NeonAnimationBehavior
@@ -47,8 +47,8 @@ Configuration:
       }
 
       this._effect = new KeyframeEffect(node, [
-        {'transform': 'translateY(0%)'},
-        {'transform': 'translateY(100%)'}
+        {'transform': 'translateY(-100%)'},
+        {'transform': 'translateY(0%)'}
       ], this.timingFromConfig(config));
 
       return this._effect;

--- a/demo/declarative/index.html
+++ b/demo/declarative/index.html
@@ -29,7 +29,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       .toolbar {
+        position: relative;
+
         padding: 8px;
+
+        background-color: white;
+
+        z-index: 12;
       }
 
     </style>
@@ -71,8 +77,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template is="dom-bind">
 
       <div class="toolbar">
-        <button on-click="_onPrevClick">&lt;&lt;</button>
-        <button on-click="_onNextClick">&gt;&gt;</button>
+        <button on-click="_onPrevClick">&#8678;</button>
+        <button on-click="_onNextClick">&#8680;</button>
+        <button on-click="_onUpClick">&#8679;</button>
+        <button on-click="_onDownClick">&#8681;</button>
       </div>
 
       <neon-animated-pages id="pages" class="flex" selected="[[selected]]" entry-animation="[[entryAnimation]]" exit-animation="[[exitAnimation]]">
@@ -100,6 +108,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.entryAnimation = 'slide-from-right-animation';
         this.exitAnimation = 'slide-left-animation';
         this.selected = this.selected === 4 ? 0 : (this.selected + 1);
+      }
+
+      scope._onUpClick = function() {
+        this.entryAnimation = 'slide-from-top-animation';
+        this.exitAnimation = 'slide-down-animation';
+        this.selected = this.selected === 4 ? 0 : (this.selected + 1);
+      }
+
+      scope._onDownClick = function() {
+        this.entryAnimation = 'slide-from-bottom-animation';
+        this.exitAnimation = 'slide-up-animation';
+        this.selected = this.selected === 0 ? 4 : (this.selected - 1);
       }
 
     </script>

--- a/guides/neon-animation.md
+++ b/guides/neon-animation.md
@@ -280,12 +280,14 @@ The new page will slide in from the right, and the old page slide away to the le
 
 Single element animations:
 
- * `fade-in-animation` Animates opacity from `0` to `1`.
- * `fade-out-animation` Animates opacity from `1` to `0`.
- * `scale-down-animation` Animates transform from `scale(1)` to `scale(0)`.
- * `scale-up-animation` Animates transform from `scale(0)` to `scale(1)`.
- * `slide-down-animation` Animates transform from `translateY(-100%)` to `none`.
- * `slide-up-animation` Animates transform from `none` to `translateY(-100%)`.
+ * `fade-in-animation` Animates opacity from `0` to `1`;
+ * `fade-out-animation` Animates opacity from `1` to `0`;
+ * `scale-down-animation` Animates transform from `scale(1)` to `scale(0)`;
+ * `scale-up-animation` Animates transform from `scale(0)` to `scale(1)`;
+ * `slide-down-animation` Animates transform from `none` to `translateY(100%)`;
+ * `slide-up-animation` Animates transform from `none` to `translateY(-100%)`;
+ * `slide-from-top-animation` Animates transform from `translateY(-100%)` to `none`;
+ * `slide-from-bottom-animation` Animates transform from `translateY(100%)` to `none`;
  * `slide-left-animation` Animates transform from `none` to `translateX(-100%)`;
  * `slide-right-animation` Animates transform from `none` to `translateX(100%)`;
  * `slide-from-left-animation` Animates transform from `translateX(-100%)` to `none`;

--- a/neon-animations.html
+++ b/neon-animations.html
@@ -18,6 +18,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="animations/scale-up-animation.html">
 <link rel="import" href="animations/slide-from-left-animation.html">
 <link rel="import" href="animations/slide-from-right-animation.html">
+<link rel="import" href="animations/slide-from-top-animation.html">
+<link rel="import" href="animations/slide-from-bottom-animation.html">
 <link rel="import" href="animations/slide-left-animation.html">
 <link rel="import" href="animations/slide-right-animation.html">
 <link rel="import" href="animations/slide-up-animation.html">


### PR DESCRIPTION
The animations `slide from right` and `slide from left` were implemented but `slide from up` and `slide from down` were missing.
Moreover, the animation `slide down` was not the expected animation.

Fixes #77, #106