### PR TITLE
Declarative page child entry and exit animations

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "neon-animation",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "authors": [
     "The Polymer Authors"
   ],

--- a/neon-animated-pages.html
+++ b/neon-animated-pages.html
@@ -82,6 +82,16 @@ animations to be run when switching to or switching out of the page.
       animateInitialSelection: {
         type: Boolean,
         value: false
+      },
+
+      childEntryAnimation: {
+        type: String,
+        value: 'entry'
+      },
+
+      childExitAnimation: {
+        type: String,
+        value: 'exit'
       }
 
     },
@@ -122,7 +132,7 @@ animations to be run when switching to or switching out of the page.
         if (selectedPage.getAnimationConfig) {
           this.animationConfig.push({
             animatable: selectedPage,
-            type: 'entry'
+            type: this.childEntryAnimation
           });
         }
       }
@@ -148,7 +158,7 @@ animations to be run when switching to or switching out of the page.
           if (oldPage.getAnimationConfig) {
             this.animationConfig.push({
               animatable: oldPage,
-              type: 'exit'
+              type: this.childExitAnimation
             });
           }
         }


### PR DESCRIPTION
Recently we found ourselves requiring multiple different transitions between animated pages. The current implementation restricts child animation types to be named 'entry' and 'exit'. This starts to limit transitions when two pages, A and B, need to be able to transition to the same target page C. When the 'to-page' animation nodes on page C need to animate differently when changing to 'from-page' A or 'from-page' B. Allowing only the 'entry' and 'exit' animation types restricts use to only two possibilities where perhaps four or more may be needed. This method further allows for declarative conditional animation to use different transition animations based on bound or computed values on page child nodes.