### PR TITLE
Use object for map rather than array

### DIFF
--- a/neon-animatable-behavior.html
+++ b/neon-animatable-behavior.html
@@ -141,7 +141,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * or a map of animation type to array of configuration objects.
      */
     getAnimationConfig: function(type) {
-      var map = [];
+      var map = {};
       var allConfigs = [];
       this._getAnimationConfigRecursive(type, map, allConfigs);
       // append the configurations saved in the map to the array


### PR DESCRIPTION
Closure compiler is adding more checks to array accessing. Here, map was being accessed with string keys on line 149 which will be an error.

`map` is local to `getAnimationConfig` and `_getAnimationConfigRecursive` and is just used as a bag of properties, so this change should be safe.