### PR TITLE
fix slide-down-animation direction

### DIFF
--- a/animations/slide-down-animation.html
+++ b/animations/slide-down-animation.html
@@ -47,8 +47,8 @@ Configuration:
       }
 
       this._effect = new KeyframeEffect(node, [
-        {'transform': 'translateY(0%)'},
-        {'transform': 'translateY(100%)'}
+        {'transform': 'translateY(-100%)'},
+        {'transform': 'translateY(0%)'}
       ], this.timingFromConfig(config));
 
       return this._effect;


### PR DESCRIPTION
broken demo: https://elements.polymer-project.org/elements/neon-animation?view=demo:demo/index.html&active=neon-animated-pages → load (toolbar is moving from 0 to 100%)