### PR TITLE
Fix inconsistencies in readme.md, neon-animation.md and slide-down

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Single element animations:
  * `fade-out-animation` Animates opacity from `1` to `0`;
  * `scale-down-animation` Animates transform from `scale(1)` to `scale(0)`;
  * `scale-up-animation` Animates transform from `scale(0)` to `scale(1)`;
- * `slide-down-animation` Animates transform from `translateY(-100%)` to `none`;
+ * `slide-down-animation` Animates transform from `none` to `translateY(100%)`;
  * `slide-up-animation` Animates transform from `none` to `translateY(-100%)`;
  * `slide-from-top-animation` Animates transform from `translateY(-100%)` to `none`;
  * `slide-from-bottom-animation` Animates transform from `translateY(100%)` to `none`;

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Single element animations:
  * `slide-right-animation` Animates transform from `none` to `translateX(100%)`;
  * `slide-from-left-animation` Animates transform from `translateX(-100%)` to `none`;
  * `slide-from-right-animation` Animates transform from `translateX(100%)` to `none`;
+ 
  * `transform-animation` Animates a custom transform.
 
 Note that there is a restriction that only one transform animation can be applied on the same element at a time. Use the custom `transform-animation` to combine transform properties.

--- a/animations/slide-down-animation.html
+++ b/animations/slide-down-animation.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../web-animations.html">
 
 <!--
-`<slide-down-animation>` animates the transform of an element from `translateY(-100%)` to `none`.
+`<slide-down-animation>` animates the transform of an element from `none` `translateY(100%)`.
 The `transformOrigin` defaults to `50% 0`.
 
 Configuration:

--- a/demo/load/full-page.html
+++ b/demo/load/full-page.html
@@ -59,7 +59,7 @@ Polymer({
       value: function() {
         return {
           'entry': [{
-            name: 'slide-down-animation',
+            name: 'slide-from-top-animation',
             node: this.$.toolbar
           }, {
             animatable: this.$.grid,

--- a/guides/neon-animation.md
+++ b/guides/neon-animation.md
@@ -109,7 +109,7 @@ Polymer({
   hide: function() {
     this.opened = false;
     // run fade-out-animation
-    this.playAnimation('fade-out-animation');
+    this.playAnimation('exit');
   },
   _onNeonAnimationFinish: function() {
     if (!this.opened) {
@@ -292,7 +292,6 @@ Single element animations:
  * `slide-right-animation` Animates transform from `none` to `translateX(100%)`;
  * `slide-from-left-animation` Animates transform from `translateX(-100%)` to `none`;
  * `slide-from-right-animation` Animates transform from `translateX(100%)` to `none`;
-
  * `transform-animation` Animates a custom transform.
 
 Note that there is a restriction that only one transform animation can be applied on the same element at a time. Use the custom `transform-animation` to combine transform properties.

--- a/guides/neon-animation.md
+++ b/guides/neon-animation.md
@@ -292,6 +292,7 @@ Single element animations:
  * `slide-right-animation` Animates transform from `none` to `translateX(100%)`;
  * `slide-from-left-animation` Animates transform from `translateX(-100%)` to `none`;
  * `slide-from-right-animation` Animates transform from `translateX(100%)` to `none`;
+ 
  * `transform-animation` Animates a custom transform.
 
 Note that there is a restriction that only one transform animation can be applied on the same element at a time. Use the custom `transform-animation` to combine transform properties.


### PR DESCRIPTION
Provides a fix for #140 rather than the incorrect fix in #138

Due to the change in slide animations, the definition of slide-down has changed. This has been fixed in the readme, demo and comments