### PR TITLE
Fixes #146 and #147

### DIFF
--- a/neon-animated-pages.html
+++ b/neon-animated-pages.html
@@ -92,6 +92,9 @@ animations to be run when switching to or switching out of the page.
     },
 
     _onIronSelect: function(event) {
+      // ignore if the event is not trigger by a page selection
+      if (event.target !== this) return;
+
       var selectedPage = event.detail.item;
       if (!selectedPage) return;
       


### PR DESCRIPTION
Fixes #146 and #147 by making sure the page transitions are only
triggered when the target of the `iron-select` event is the element
itself.