### PR TITLE
Fixes #146 and #147

### DIFF
--- a/neon-animated-pages.html
+++ b/neon-animated-pages.html
@@ -93,6 +93,9 @@ animations to be run when switching to or switching out of the page.
     },
 
     _onIronSelect: function(event) {
+      // ignore if the event is not trigger by a page selection
+      if (Polymer.dom(event).rootTarget !== this) return;
+
       var selectedPage = event.detail.item;
       if (!selectedPage) return;
       

--- a/test/neon-animated-pages.html
+++ b/test/neon-animated-pages.html
@@ -28,6 +28,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../animations/slide-from-left-animation.html">
   <link rel="import" href="../animations/slide-right-animation.html">
   <link rel="import" href="test-resizable-pages.html">
+  <link rel="import" href="test-page-with-nested-selector.html">
 
 </head>
 <body>
@@ -54,6 +55,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <neon-animated-pages entry-animation="slide-from-left-animation" exit-animation="slide-right-animation" animate-initial-selection>
         <neon-animatable></neon-animatable>
         <neon-animatable></neon-animatable>
+      </neon-animated-pages>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="bubbling-iron-select">
+    <template>
+      <neon-animated-pages selected="0">
+        <page-with-nested-selector></page-with-nested-selector>
+        <page-with-nested-selector></page-with-nested-selector>
       </neon-animated-pages>
     </template>
   </test-fixture>
@@ -93,6 +103,40 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           done();
         });
         animatedPages.selected = 0;
+      });
+    });
+    suite('non-regression', function() {
+      test('bubbling \'iron-select\' should not trigger a transition', function(done) {
+        var animatedPages = fixture('bubbling-iron-select');
+        var pages = Polymer.dom(animatedPages).children;
+        assert.strictEqual(Number(animatedPages.selected), 0);
+        // Run an animated transition once (required)
+        animatedPages.selected = 1;
+        pages.forEach(function(page) {
+          page.nestedSelector.selected = 0;
+        });
+
+        setTimeout(function() {
+          // Change selections on iron-selectors nested in pages
+          assert.strictEqual(Number(animatedPages.selected), 1);
+          pages.forEach(function(page) {
+            assert.strictEqual(Number(page.nestedSelector.selected), 0);
+          });
+          
+          // We fail if we detect an animated transition
+          animatedPages.addEventListener('neon-animation-finish', function(event) {
+            assert.fail();
+          });
+          pages.forEach(function(page) {
+            page.nestedSelector.selected = 1;
+          });
+          setTimeout(function() {
+            pages.forEach(function(page) {
+              assert.strictEqual(Number(page.nestedSelector.selected), 1);
+            });
+            done();
+          }, 600);
+        }, 600);
       });
     });
   </script>

--- a/test/test-page-with-nested-selector.html
+++ b/test/test-page-with-nested-selector.html
@@ -1,0 +1,64 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../iron-selector/iron-selector.html">
+<link rel="import" href="../neon-animatable-behavior.html">
+<link rel="import" href="../animations/opaque-animation.html">
+
+<dom-module id="page-with-nested-selector">
+  <template>
+    <iron-selector id="selector" selected="0">
+      <div>Item 1</div>
+      <div>Item 2</div>
+      <div>Item 3</div>
+    </iron-selector>
+  </template>
+</dom-module>
+
+<script>
+(function() {
+
+  Polymer({
+    is: 'page-with-nested-selector',
+
+    behaviors: [
+      Polymer.NeonAnimatableBehavior
+    ],
+
+    properties: {
+      animationConfig: {
+        type: Object,
+        value: function() {
+          return {
+            'entry': {
+              name: 'opaque-animation',
+              node: this
+            },
+            'exit': {
+              name: 'opaque-animation',
+              node: this
+            }
+          };
+        }
+      }
+    }, 
+
+    get nestedSelector() {
+      return this.$.selector;
+    },
+
+    set nestedSelector(value) {
+      // do nothing
+    }
+  });
+
+})();
+</script>


### PR DESCRIPTION
Fixes #146 and #147 by making sure the page transitions are only
triggered when the target of the `iron-select` event is the element
itself.