### PR TITLE
Remove redundant height css property

### DIFF
--- a/neon-animated-pages.html
+++ b/neon-animated-pages.html
@@ -39,7 +39,6 @@ animations to be run when switching to or switching out of the page.
       left: 0;
       bottom: 0;
       right: 0;
-      height: 100%;
     }
 
     :host > ::content > :not(.iron-selected):not(.neon-animating) {


### PR DESCRIPTION
I'd like to have this removed because it's redundant and it frequently just causes trouble in my styles. Instead of constantly resetting it to auto, I'd be much nicer if it weren't there in the first place.

Example:
```HTML
<neon-animated-pages>
  <div style="padding: 10px;">I am too tall</div>
</neon-animated-pages>
```

Without `height: 100%` the above example just works. Everything else behaves the same.