### PR TITLE
Makes compatible with Polymer 1.4's `lazyRegister` setting

### DIFF
--- a/animations/cascaded-animation.html
+++ b/animations/cascaded-animation.html
@@ -38,18 +38,6 @@ Configuration:
       Polymer.NeonAnimationBehavior
     ],
 
-    properties: {
-
-      /** @type {!Polymer.IronMeta} */
-      _animationMeta: {
-        type: Object,
-        value: function() {
-          return new Polymer.IronMeta({type: 'animation'});
-        }
-      }
-
-    },
-
     /**
      * @param {{
      *   animation: string,
@@ -59,13 +47,6 @@ Configuration:
      *  }} config
      */
     configure: function(config) {
-      var animationConstructor = /** @type {Function} */ (
-          this._animationMeta.byKey(config.animation));
-      if (!animationConstructor) {
-        console.warn(this.is + ':', 'constructor for', config.animation, 'not found!');
-        return;
-      }
-
       this._animations = [];
       var nodes = config.nodes;
       var effects = [];
@@ -79,11 +60,15 @@ Configuration:
         config.timing.delay += nodeDelay;
         config.node = node;
 
-        var animation = new animationConstructor();
-        var effect = animation.configure(config);
+        var animation = document.createElement(config.animation);
+        if (animation.isNeonAnimation) {
+          var effect = animation.configure(config);
 
-        this._animations.push(animation);
-        effects.push(effect);
+          this._animations.push(animation);
+          effects.push(effect);
+        } else {
+          console.warn(this.is + ':', config.animation, 'not found!');
+        }
       }
       config.timing.delay = oldDelay;
 

--- a/animations/cascaded-animation.html
+++ b/animations/cascaded-animation.html
@@ -56,6 +56,7 @@ Configuration:
       config.timing.delay = config.timing.delay || 0;
 
       var oldDelay = config.timing.delay;
+      var abortedConfigure;
       for (var node, index = 0; node = nodes[index]; index++) {
         config.timing.delay += nodeDelay;
         config.node = node;
@@ -68,9 +69,16 @@ Configuration:
           effects.push(effect);
         } else {
           console.warn(this.is + ':', config.animation, 'not found!');
+          abortedConfigure = true;
+          break;
         }
       }
       config.timing.delay = oldDelay;
+      config.node = null;
+      // if a bad animation was configured, abort config.
+      if (abortedConfigure) {
+        return;
+      }
 
       this._effect = new GroupEffect(effects);
       return this._effect;

--- a/neon-animation-behavior.html
+++ b/neon-animation-behavior.html
@@ -37,9 +37,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     },
 
-    registered: function() {
-      new Polymer.IronMeta({type: 'animation', key: this.is, value: this.constructor});
-    },
+    /**
+     * Can be used to determine that elements implement this behavior.
+     */
+    isNeonAnimation: true,
 
     /**
      * Do any animation configuration here.

--- a/neon-animation-runner-behavior.html
+++ b/neon-animation-runner-behavior.html
@@ -21,13 +21,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     properties: {
 
-      _animationMeta: {
-        type: Object,
-        value: function() {
-          return new Polymer.IronMeta({type: 'animation'});
-        }
-      },
-
       /** @type {?Object} */
       _player: {
         type: Object
@@ -39,9 +32,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var allAnimations = [];
       if (allConfigs.length > 0) {
         for (var config, index = 0; config = allConfigs[index]; index++) {
-          var animationConstructor = this._animationMeta.byKey(config.name);
-          if (animationConstructor) {
-            var animation = animationConstructor && new animationConstructor();
+          var animation = document.createElement(config.name);
+          // is this element actually a neon animation?
+          if (animation.isNeonAnimation) {
             var effect = animation.configure(config);
             if (effect) {
               allAnimations.push({

--- a/test/index.html
+++ b/test/index.html
@@ -15,7 +15,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     WCT.loadSuites([
       'neon-animated-pages.html',
-      'neon-animated-pages.html?dom=shadow'
+      'neon-animated-pages.html?dom=shadow',
+      'neon-animated-pages-lazy.html',
+      'neon-animated-pages-lazy.html?dom=shadow'
     ]);
   </script>
 

--- a/test/neon-animated-pages-lazy.html
+++ b/test/neon-animated-pages-lazy.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!--
-Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
 The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
 The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt

--- a/test/neon-animated-pages-lazy.html
+++ b/test/neon-animated-pages-lazy.html
@@ -18,6 +18,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
+  <script>Polymer = {lazyRegister: true}</script>
+
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
@@ -31,23 +33,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body>
 
-  <test-fixture id="basic">
-    <template>
-      <neon-animated-pages>
-      </neon-animated-pages>
-    </template>
-  </test-fixture>
-
-  <test-fixture id="notify-resize">
-    <template>
-      <neon-animated-pages>
-        <a-resizable-page></a-resizable-page>
-        <b-resizable-page></b-resizable-page>
-        <c-resizable-page></c-resizable-page>
-      </neon-animated-pages>
-    </template>
-  </test-fixture>
-
   <test-fixture id="animate-initial-selection">
     <template>
       <neon-animated-pages entry-animation="slide-from-left-animation" exit-animation="slide-right-animation" animate-initial-selection>
@@ -58,37 +43,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </test-fixture>
 
   <script>
-    suite('basic', function() {
-    });
-    suite('notify-resize', function() {
-      test('only a destination page recieves a resize event', function(done) {
-        var animatedPages = fixture('notify-resize');
-        var resizables = Polymer.dom(animatedPages).children;
-        var recieves = {};
-        resizables.forEach(function(page) {
-          page.addEventListener('iron-resize', function(event) {
-            var pageName = event.currentTarget.tagName;
-            recieves[pageName] = pageName in recieves ? recieves[pageName] + 1 : 1;
-          });
-        });
-        animatedPages.selected = 2;
-        setTimeout(function() {
-          assert.deepEqual(recieves, {
-            'C-RESIZABLE-PAGE': 1
-          });
-          done();
-        }, 50);
-      });
-    });
-    suite('animate-initial-selection', function() {
-      test('\'neon-animation-finish\' event fired after animating initial selection', function(done) {
+    suite('animations found when `lazRegister` setting is true', function() {
+      test('animations are registered', function(done) {
         var animatedPages = fixture('animate-initial-selection');
+        animatedPages._completeAnimations = sinon.spy();
         assert.isUndefined(animatedPages.selected);
         var pages = Polymer.dom(animatedPages).children;
         animatedPages.addEventListener('neon-animation-finish', function(event) {
-          assert.strictEqual(animatedPages.selected, 0);
-          assert.isFalse(event.detail.fromPage);
-          assert.deepEqual(event.detail.toPage, pages[0]);
+          if (animatedPages.selected === 0) {
+            animatedPages.selected = 1;
+            return;
+          }
+          assert.strictEqual(animatedPages.selected, 1);
+          assert.equal(event.detail.fromPage, pages[0]);
+          assert.equal(event.detail.toPage, pages[1]);
+          assert.isTrue(animatedPages._completeAnimations.calledTwice);
+          var a$ = animatedPages._completeAnimations.getCall(1).args[0];
+          assert.isTrue(a$[0].animation.isNeonAnimation, 'default animation is not a registered animation');
+          assert.isTrue(a$[1].animation.isNeonAnimation, 'entry animation is not a registered animation');
+          assert.isTrue(a$[2].animation.isNeonAnimation, 'exit animation is not a registered animation');
           done();
         });
         animatedPages.selected = 0;


### PR DESCRIPTION
Fixes #155. Removes use of `iron-meta` in favor of referencing animation element name directly. This removes problematic use of the `registered` method in `NeonAnimationBehavior`. Since `registered` is called on first instance creation when `lazyRegister` is true, it should not be relied upon to provide information to another element type.