### PR TITLE
neon-animated-pages: only consider child elements

### DIFF
--- a/neon-animated-pages.html
+++ b/neon-animated-pages.html
@@ -94,7 +94,16 @@ animations to be run when switching to or switching out of the page.
 
     _onIronSelect: function(event) {
       var selectedPage = event.detail.item;
-      if (!selectedPage) return;
+
+      // Only consider child elements.
+      if (!(selectedPage instanceof Element)) return;
+      if (Polymer.dom(selectedPage).parentNode != this &&
+          Polymer.dom(selectedPage).getDestinationInsertionPoints().
+              every(function(insertionPoint) {
+                return Polymer.dom(insertionPoint).parentNode != this;
+              }.bind(this))) {
+        return;
+      }
       
       var oldPage = this._valueToItem(this._prevSelected) || false;
       this._prevSelected = this.selected;

--- a/test/index.html
+++ b/test/index.html
@@ -18,7 +18,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'neon-animated-pages.html',
       'neon-animated-pages.html?dom=shadow',
       'neon-animated-pages-lazy.html',
-      'neon-animated-pages-lazy.html?dom=shadow'
+      'neon-animated-pages-lazy.html?dom=shadow',
+      'neon-animated-pages-descendant-selection.html',
+      'neon-animated-pages-descendant-selection.html?dom=shadow',
     ]);
   </script>
 

--- a/test/neon-animated-pages-descendant-selection.html
+++ b/test/neon-animated-pages-descendant-selection.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<meta charset="utf-8">
+<meta http-equiv="x-ua-compatible" content="ie=edge,chrome=1">
+<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+<script src="../../web-component-tester/browser.js"></script>
+<script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+<link rel="import" href="../../test-fixture/test-fixture.html">
+<link rel="import" href="../../neon-animation/neon-animated-pages.html">
+<link rel="import" href="../../neon-animation/neon-animation-behavior.html">
+<link rel="import" href="../../iron-selector/iron-selector.html">
+
+<script>
+Polymer({
+  is: 'test-animation',
+  behaviors: [
+    Polymer.NeonAnimationBehavior
+  ],
+  configure: function(config) {
+    config.node.animated = true;
+  }
+});
+</script>
+
+<test-fixture id="descendant-selection">
+  <template>
+    <neon-animated-pages entry-animation="test-animation" animate-initial-selection>
+      <iron-selector selected="0" id="selector">
+        <div>1</div>
+        <div id="target">2</div>
+      </iron-selector>
+    </neon-animated-pages>
+  </template>
+</test-fixture>
+
+<dom-module id="test-element">
+  <template>
+    <neon-animated-pages entry-animation="test-animation" animate-initial-selection>
+      <content></content>
+    </neon-animated-pages>
+  </template>
+</dom-module>
+
+<script>Polymer({is: 'test-element'});</script>
+
+<test-fixture id="distributed-children">
+  <template>
+    <test-element>
+      <div>1</div>
+      <div id="target">2</div>
+    </test-element>
+  </template>
+</test-fixture>
+
+
+<script>
+suite('descendant selection', function() {
+  test('descendents of other selectors are not animated', function() {
+    var animatedPages = fixture('descendant-selection');
+    var selector = Polymer.dom(animatedPages).querySelector('#selector');
+    var target = Polymer.dom(animatedPages).querySelector('#target');
+    Polymer.dom(selector).setAttribute('selected', '1');
+    assert(!target.animated);
+  });
+  test('elements distributed as children are animated', function() {
+    var testElement = fixture('distributed-children');
+    var target = Polymer.dom(testElement).querySelector('#target');
+    var animatedPages = Polymer.dom(testElement.root).querySelector("neon-animated-pages");
+    Polymer.dom(animatedPages).setAttribute('selected', '1');
+    assert(target.animated);
+  });
+});
+</script>


### PR DESCRIPTION
Previously any descendant that fired an iron-select event could
trigger animation.

Fixes https://github.com/PolymerElements/neon-animation/issues/146