### PR TITLE
Update bower.json web-animations-js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "iron-meta": "PolymerElements/iron-meta#^1.0.0",
     "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^1.0.0",
     "iron-selector": "PolymerElements/iron-selector#^1.0.0",
-    "web-animations-js": "web-animations/web-animations-js#^2.2.0"
+    "web-animations-js": "web-animations/web-animations-js#^2.2.1"
   },
   "devDependencies": {
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",


### PR DESCRIPTION
Updating web-animation-js package to fix bugs that are documented here: https://github.com/web-animations/web-animations-js/releases/tag/2.2.1. I was receiving type errors in multiple browsers when using neon-animated-pages.