### PR TITLE
Move style updates after effect creation

### DIFF
--- a/animations/scale-down-animation.html
+++ b/animations/scale-down-animation.html
@@ -41,10 +41,6 @@ Configuration:
     configure: function(config) {
       var node = config.node;
 
-      if (config.transformOrigin) {
-        this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
-      }
-
       var scaleProperty = 'scale(0, 0)';
       if (config.axis === 'x') {
         scaleProperty = 'scale(0, 1)';
@@ -56,6 +52,10 @@ Configuration:
         {'transform': 'scale(1,1)'},
         {'transform': scaleProperty}
       ], this.timingFromConfig(config));
+
+      if (config.transformOrigin) {
+        this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
+      }
 
       return this._effect;
     }

--- a/animations/scale-up-animation.html
+++ b/animations/scale-up-animation.html
@@ -41,10 +41,6 @@ Configuration:
     configure: function(config) {
       var node = config.node;
 
-      if (config.transformOrigin) {
-        this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
-      }
-
       var scaleProperty = 'scale(0)';
       if (config.axis === 'x') {
         scaleProperty = 'scale(0, 1)';
@@ -56,6 +52,10 @@ Configuration:
         {'transform': scaleProperty},
         {'transform': 'scale(1, 1)'}
       ], this.timingFromConfig(config));
+
+      if (config.transformOrigin) {
+        this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
+      }
 
       return this._effect;
     }

--- a/animations/slide-down-animation.html
+++ b/animations/slide-down-animation.html
@@ -40,16 +40,16 @@ Configuration:
     configure: function(config) {
       var node = config.node;
 
+      this._effect = new KeyframeEffect(node, [
+        {'transform': 'translateY(0%)'},
+        {'transform': 'translateY(100%)'}
+      ], this.timingFromConfig(config));
+
       if (config.transformOrigin) {
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
       } else {
         this.setPrefixedProperty(node, 'transformOrigin', '50% 0');
       }
-
-      this._effect = new KeyframeEffect(node, [
-        {'transform': 'translateY(0%)'},
-        {'transform': 'translateY(100%)'}
-      ], this.timingFromConfig(config));
 
       return this._effect;
     }

--- a/animations/slide-from-bottom-animation.html
+++ b/animations/slide-from-bottom-animation.html
@@ -40,16 +40,16 @@ Configuration:
     configure: function(config) {
       var node = config.node;
 
+      this._effect = new KeyframeEffect(node, [
+        {'transform': 'translateY(100%)'},
+        {'transform': 'translateY(0)'}
+      ], this.timingFromConfig(config));
+
       if (config.transformOrigin) {
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
       } else {
         this.setPrefixedProperty(node, 'transformOrigin', '50% 0');
       }
-
-      this._effect = new KeyframeEffect(node, [
-        {'transform': 'translateY(100%)'},
-        {'transform': 'translateY(0)'}
-      ], this.timingFromConfig(config));
 
       return this._effect;
     }

--- a/animations/slide-from-left-animation.html
+++ b/animations/slide-from-left-animation.html
@@ -41,16 +41,16 @@ Configuration:
     configure: function(config) {
       var node = config.node;
 
+      this._effect = new KeyframeEffect(node, [
+        {'transform': 'translateX(-100%)'},
+        {'transform': 'none'}
+      ], this.timingFromConfig(config));
+
       if (config.transformOrigin) {
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
       } else {
         this.setPrefixedProperty(node, 'transformOrigin', '0 50%');
       }
-
-      this._effect = new KeyframeEffect(node, [
-        {'transform': 'translateX(-100%)'},
-        {'transform': 'none'}
-      ], this.timingFromConfig(config));
 
       return this._effect;
     }

--- a/animations/slide-from-right-animation.html
+++ b/animations/slide-from-right-animation.html
@@ -41,16 +41,16 @@ Configuration:
     configure: function(config) {
       var node = config.node;
 
+      this._effect = new KeyframeEffect(node, [
+        {'transform': 'translateX(100%)'},
+        {'transform': 'none'}
+      ], this.timingFromConfig(config));
+
       if (config.transformOrigin) {
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
       } else {
         this.setPrefixedProperty(node, 'transformOrigin', '0 50%');
       }
-
-      this._effect = new KeyframeEffect(node, [
-        {'transform': 'translateX(100%)'},
-        {'transform': 'none'}
-      ], this.timingFromConfig(config));
 
       return this._effect;
     }

--- a/animations/slide-from-top-animation.html
+++ b/animations/slide-from-top-animation.html
@@ -40,16 +40,16 @@ Configuration:
     configure: function(config) {
       var node = config.node;
 
+      this._effect = new KeyframeEffect(node, [
+        {'transform': 'translateY(-100%)'},
+        {'transform': 'translateY(0%)'}
+      ], this.timingFromConfig(config));
+
       if (config.transformOrigin) {
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
       } else {
         this.setPrefixedProperty(node, 'transformOrigin', '50% 0');
       }
-
-      this._effect = new KeyframeEffect(node, [
-        {'transform': 'translateY(-100%)'},
-        {'transform': 'translateY(0%)'}
-      ], this.timingFromConfig(config));
 
       return this._effect;
     }

--- a/animations/slide-left-animation.html
+++ b/animations/slide-left-animation.html
@@ -40,16 +40,16 @@ Configuration:
     configure: function(config) {
       var node = config.node;
 
+      this._effect = new KeyframeEffect(node, [
+        {'transform': 'none'},
+        {'transform': 'translateX(-100%)'}
+      ], this.timingFromConfig(config));
+
       if (config.transformOrigin) {
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
       } else {
         this.setPrefixedProperty(node, 'transformOrigin', '0 50%');
       }
-
-      this._effect = new KeyframeEffect(node, [
-        {'transform': 'none'},
-        {'transform': 'translateX(-100%)'}
-      ], this.timingFromConfig(config));
 
       return this._effect;
     }

--- a/animations/slide-right-animation.html
+++ b/animations/slide-right-animation.html
@@ -40,16 +40,16 @@ Configuration:
     configure: function(config) {
       var node = config.node;
 
+      this._effect = new KeyframeEffect(node, [
+        {'transform': 'none'},
+        {'transform': 'translateX(100%)'}
+      ], this.timingFromConfig(config));
+
       if (config.transformOrigin) {
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
       } else {
         this.setPrefixedProperty(node, 'transformOrigin', '0 50%');
       }
-
-      this._effect = new KeyframeEffect(node, [
-        {'transform': 'none'},
-        {'transform': 'translateX(100%)'}
-      ], this.timingFromConfig(config));
 
       return this._effect;
     }

--- a/animations/slide-up-animation.html
+++ b/animations/slide-up-animation.html
@@ -40,16 +40,16 @@ Configuration:
     configure: function(config) {
       var node = config.node;
 
+      this._effect = new KeyframeEffect(node, [
+        {'transform': 'translate(0)'},
+        {'transform': 'translateY(-100%)'}
+      ], this.timingFromConfig(config));
+
       if (config.transformOrigin) {
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
       } else {
         this.setPrefixedProperty(node, 'transformOrigin', '50% 0');
       }
-
-      this._effect = new KeyframeEffect(node, [
-        {'transform': 'translate(0)'},
-        {'transform': 'translateY(-100%)'}
-      ], this.timingFromConfig(config));
 
       return this._effect;
     }

--- a/animations/transform-animation.html
+++ b/animations/transform-animation.html
@@ -53,14 +53,14 @@ Configuration:
       var transformFrom = config.transformFrom || 'none';
       var transformTo = config.transformTo || 'none';
 
-      if (config.transformOrigin) {
-        this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
-      }
-
       this._effect = new KeyframeEffect(node, [
         {'transform': transformFrom},
         {'transform': transformTo}
       ], this.timingFromConfig(config));
+
+      if (config.transformOrigin) {
+        this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
+      }
 
       return this._effect;
     }


### PR DESCRIPTION
Avoids overwriting styles in the event that an effect cannot be created.

Follow on to https://github.com/PolymerElements/neon-animation/pull/177