### PR TITLE
cascaded-animation without a first delay

### DIFF
--- a/animations/cascaded-animation.html
+++ b/animations/cascaded-animation.html
@@ -58,7 +58,7 @@ Configuration:
       var oldDelay = config.timing.delay;
       var abortedConfigure;
       for (var node, index = 0; node = nodes[index]; index++) {
-        config.timing.delay += nodeDelay;
+        config.timing.delay =  oldDelay + nodeDelay * index;
         config.node = node;
 
         var animation = document.createElement(config.animation);

--- a/test/cascaded-animation.html
+++ b/test/cascaded-animation.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+
+  <title>cascaded-animation tests</title>
+
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+  <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="../animations/cascaded-animation.html">
+  <link rel="import" href="../animations/fade-in-animation.html">
+
+</head>
+<body>
+
+<test-fixture id="cascadedAnimation">
+  <template>
+    <cascaded-animation></cascaded-animation>
+  </template>
+</test-fixture>
+
+
+<script>
+  suite('cascaded-animation', function () {
+    test('the first animation should be have no delay and the flowing animations an increasing delay of 1000', function () {
+      var cascadedAnimation = fixture('cascadedAnimation');
+      var effects = cascadedAnimation.configure({
+        "animation": "fade-in-animation",
+        nodes: [document.createElement("div"), document.createElement("div"), document.createElement("div")],
+        nodeDelay: 1000
+      });
+
+      expect(effects.children.length).to.equal(3);
+      expect(effects._timing._delay).to.equal(0);
+      expect(effects.children[0]._timing._delay).to.equal(0);
+      expect(effects.children[1]._timing._delay).to.equal(1000);
+      expect(effects.children[2]._timing._delay).to.equal(2000);
+    });
+
+    test('the first animation should be have a delay of 500ms and the flowing an increasing delay of 1000', function () {
+      var cascadedAnimation = fixture('cascadedAnimation');
+      var effects = cascadedAnimation.configure({
+        "animation": "fade-in-animation",
+        nodes: [document.createElement("div"), document.createElement("div"), document.createElement("div")],
+        nodeDelay: 1000,
+        timing: {
+          "delay": 500
+        }
+      });
+
+      expect(effects.children.length).to.equal(3);
+      expect(effects._timing._delay).to.equal(0);
+      expect(effects.children[0]._timing._delay).to.equal(500);
+      expect(effects.children[1]._timing._delay).to.equal(1500);
+      expect(effects.children[2]._timing._delay).to.equal(2500);
+    });
+  });
+</script>
+
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -21,6 +21,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'neon-animated-pages-lazy.html?dom=shadow',
       'neon-animated-pages-descendant-selection.html',
       'neon-animated-pages-descendant-selection.html?dom=shadow',
+      'cascaded-animation.html',
+      'cascaded-animation.html?dom=shadow'
     ]);
   </script>
 


### PR DESCRIPTION
### Description
Currently it is not possible to to run a cascaded-animation without a first delay.

### Expected outcome

> `<cascaded-animation>` applies an animation on an array of elements with a delay **between** each.
> the delay defaults to 50ms.

`` 0ms | animation1 |  nodeDelay ms | animation2 |  nodeDelay ms |  animation3``


Setting `nodeDelay = 1000` and `timing.delay  = 0` should run the first animation after 0ms and then the following with `nodeDelay`.

### Actual outcome

`` nodeDelay ms | animation1 |  nodeDelay ms | animation2 |  nodeDelay ms |  animation3``

The first animation has a delay of `nodeDelay` and therefor the initial animation is delayed by `nodeDelay` ms

### Browsers Affected

- [X] Chrome
- [X] Firefox
- [X] Safari 9
- [X] Safari 8
- [X] Safari 7
- [X] Edge
- [X] IE 11
- [X] IE 10


This PR  addresses and fixes the issue.