### PR TITLE
Fix tiles demo

### DIFF
--- a/demo/tiles/circles-page.html
+++ b/demo/tiles/circles-page.html
@@ -82,7 +82,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _onClick: function(event) {
-      var target = event.target;
+      var target = Polymer.dom(event).rootTarget;
       if (target.classList.contains('circle')) {
         // configure the page animation
         this.sharedElements = {


### PR DESCRIPTION
Because the `listeners` block gets applied to the element itself, the events coming from its children are retargeted if you set `dom: shadow`. Therefore the check for `.circle` never matches (instead it's always `circle-page`). This fixes that.