### PR TITLE
Fixes #215

### DIFF
--- a/neon-animation-runner-behavior.html
+++ b/neon-animation-runner-behavior.html
@@ -32,7 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             try {
               result = neonAnimation.configure(config);
               // Check if we have an Effect rather than an Animation
-              if (typeof result.cancel != 'function') { 
+              if (typeof result.cancel != 'function') {
                 result = document.timeline.play(result);
               }
             } catch (e) {
@@ -114,10 +114,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Cancels the currently running animations.
      */
     cancelAnimation: function() {
-      for (var k in this._animations) {
-        this._animations[k].cancel();
+      for (var k in this._active) {
+        for (var i in this._active[k]){
+          this._active[k][i].animation.cancel();
+        }
+        delete this._active[k];
       }
-      this._animations = {};
     }
   };
 


### PR DESCRIPTION
Fixes #215 by iterating through _active rather than _animations. This also could make canceling per-cookie/handler possible:
```
cancelAnimation: function(cookie) {
  for (var i in this._active[cookie]){
    this._active[cookie][i].animation.cancel();
  }
  delete this._active[cookie];
}
```

Tested in Chrome 55.