### PR TITLE
Fix concurrent animations

### DIFF
--- a/neon-animation-runner-behavior.html
+++ b/neon-animation-runner-behavior.html
@@ -133,11 +133,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     /**
      * Cancels the currently running animations.
      */
-     cancelAnimation: function() {
-      for (var k in this._animations) {
-        this._animations[k].cancel();
+    cancelAnimation: function() {
+      for (var k in this._active) {
+        var entries = this._active[k]
+
+        for (var j in entries) {
+          entries[j].animation.cancel();
+        }
       }
-      this._animations = {};
+
+      this._active = {};
     }
   };
 

--- a/neon-animation-runner-behavior.html
+++ b/neon-animation-runner-behavior.html
@@ -29,7 +29,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // is this element actually a neon animation?
           if (neonAnimation.isNeonAnimation) {
             var result = null;
-            // Closure compilation
+            // Closure compiler does not work well with a try / catch here. .configure needs to be
+            // explicitly defined
             if (!neonAnimation.configure) {
               /**
                * @param {Object} config

--- a/neon-animation-runner-behavior.html
+++ b/neon-animation-runner-behavior.html
@@ -21,35 +21,56 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _configureAnimations: function(configs) {
       var results = [];
+      var resultsToPlay = [];
+
       if (configs.length > 0) {
         for (var config, index = 0; config = configs[index]; index++) {
           var neonAnimation = document.createElement(config.name);
           // is this element actually a neon animation?
           if (neonAnimation.isNeonAnimation) {
             var result = null;
-            // configuration or play could fail if polyfills aren't loaded
-            try {
-              result = neonAnimation.configure(config);
-              // Check if we have an Effect rather than an Animation
-              if (typeof result.cancel != 'function') {
-                result = document.timeline.play(result);
+            // Closure compilation
+            if (!neonAnimation.configure) {
+              /**
+               * @param {Object} config
+               * @return {AnimationEffectReadOnly}
+               */
+              neonAnimation.configure = function(config) {
+                return null;
               }
-            } catch (e) {
-              result = null;
-              console.warn('Couldnt play', '(', config.name, ').', e);
             }
-            if (result) {
-              results.push({
-                neonAnimation: neonAnimation,
-                config: config,
-                animation: result,
-              });
-            }
+
+            result = neonAnimation.configure(config);
+            resultsToPlay.push({ result: result, config: config });
           } else {
             console.warn(this.is + ':', config.name, 'not found!');
           }
         }
       }
+
+      for (var i = 0; i < resultsToPlay.length; i++) {
+        var result = resultsToPlay[i].result;
+        var config = resultsToPlay[i].config;
+        // configuration or play could fail if polyfills aren't loaded
+        try {
+          // Check if we have an Effect rather than an Animation
+          if (typeof result.cancel != 'function') {
+            result = document.timeline.play(result);
+          }
+        } catch (e) {
+          result = null;
+          console.warn('Couldnt play', '(', config.name, ').', e);
+        }
+
+        if (result) {
+          results.push({
+            neonAnimation: neonAnimation,
+            config: config,
+            animation: result,
+          });
+        }
+      }
+
       return results;
     },
 
@@ -112,7 +133,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     /**
      * Cancels the currently running animations.
      */
-    cancelAnimation: function() {
+     cancelAnimation: function() {
       for (var k in this._animations) {
         this._animations[k].cancel();
       }


### PR DESCRIPTION
Fix animations that were not playing concurrently. This used to work when we used `GroupEffect` to play the animations, but when we changed to `document.timeline.play(...)`, and that change did not bulk the animations together.

Additionally, `cancelAnimation` was broken in an update and never fixed.