### PR TITLE
Automatic format!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ before_script:
     npm run update-types && git diff --exit-code || (echo -e
     '\n\033[31mERROR:\033[0m Typings are stale. Please run "npm run
     update-types".' && false)
+  - >-
+    npm run format && git diff --exit-code || (echo -e '\n\033[31mERROR:\033[0m
+    Project is not formatted. Please run "npm run format".' && false)
 script:
   - xvfb-run polymer test
   - >-

--- a/animations/cascaded-animation.html
+++ b/animations/cascaded-animation.html
@@ -28,14 +28,11 @@ Configuration:
 -->
 
 <script>
-
   Polymer({
 
     is: 'cascaded-animation',
 
-    behaviors: [
-      Polymer.NeonAnimationBehavior
-    ],
+    behaviors: [Polymer.NeonAnimationBehavior],
 
     /**
      * @param {{
@@ -84,11 +81,11 @@ Configuration:
     },
 
     complete: function() {
-      for (var animation, index = 0; animation = this._animations[index]; index++) {
+      for (var animation, index = 0; animation = this._animations[index];
+           index++) {
         animation.complete(animation.config);
       }
     }
 
   });
-
 </script>

--- a/animations/fade-in-animation.html
+++ b/animations/fade-in-animation.html
@@ -25,24 +25,20 @@ Configuration:
 -->
 
 <script>
-
   Polymer({
 
     is: 'fade-in-animation',
 
-    behaviors: [
-      Polymer.NeonAnimationBehavior
-    ],
+    behaviors: [Polymer.NeonAnimationBehavior],
 
     configure: function(config) {
       var node = config.node;
-      this._effect = new KeyframeEffect(node, [
-        {'opacity': '0'},
-        {'opacity': '1'}
-      ], this.timingFromConfig(config));
+      this._effect = new KeyframeEffect(
+          node,
+          [{'opacity': '0'}, {'opacity': '1'}],
+          this.timingFromConfig(config));
       return this._effect;
     }
 
   });
-
 </script>

--- a/animations/fade-out-animation.html
+++ b/animations/fade-out-animation.html
@@ -25,24 +25,20 @@ Configuration:
 -->
 
 <script>
-
   Polymer({
 
     is: 'fade-out-animation',
 
-    behaviors: [
-      Polymer.NeonAnimationBehavior
-    ],
+    behaviors: [Polymer.NeonAnimationBehavior],
 
     configure: function(config) {
       var node = config.node;
-      this._effect = new KeyframeEffect(node, [
-        {'opacity': '1'},
-        {'opacity': '0'}
-      ], this.timingFromConfig(config));
+      this._effect = new KeyframeEffect(
+          node,
+          [{'opacity': '1'}, {'opacity': '0'}],
+          this.timingFromConfig(config));
       return this._effect;
     }
 
   });
-
 </script>

--- a/animations/hero-animation.html
+++ b/animations/hero-animation.html
@@ -33,14 +33,11 @@ Configuration:
 -->
 
 <script>
-
   Polymer({
 
     is: 'hero-animation',
 
-    behaviors: [
-      Polymer.NeonSharedElementAnimationBehavior
-    ],
+    behaviors: [Polymer.NeonSharedElementAnimationBehavior],
 
     configure: function(config) {
       var shared = this.findSharedElements(config);
@@ -56,10 +53,16 @@ Configuration:
       var deltaWidth = fromRect.width / toRect.width;
       var deltaHeight = fromRect.height / toRect.height;
 
-      this._effect = new KeyframeEffect(shared.to, [
-        {'transform': 'translate(' + deltaLeft + 'px,' + deltaTop + 'px) scale(' + deltaWidth + ',' + deltaHeight + ')'},
-        {'transform': 'none'}
-      ], this.timingFromConfig(config));
+      this._effect = new KeyframeEffect(
+          shared.to,
+          [
+            {
+              'transform': 'translate(' + deltaLeft + 'px,' + deltaTop +
+                  'px) scale(' + deltaWidth + ',' + deltaHeight + ')'
+            },
+            {'transform': 'none'}
+          ],
+          this.timingFromConfig(config));
 
       this.setPrefixedProperty(shared.to, 'transformOrigin', '0 0');
       shared.to.style.zIndex = 10000;
@@ -78,5 +81,4 @@ Configuration:
     }
 
   });
-
 </script>

--- a/animations/opaque-animation.html
+++ b/animations/opaque-animation.html
@@ -17,21 +17,18 @@ webkit/safari from drawing a frame before an animation for elements that animate
 -->
 
 <script>
-
   Polymer({
 
     is: 'opaque-animation',
 
-    behaviors: [
-      Polymer.NeonAnimationBehavior
-    ],
+    behaviors: [Polymer.NeonAnimationBehavior],
 
     configure: function(config) {
       var node = config.node;
-      this._effect = new KeyframeEffect(node, [
-        {'opacity': '1'},
-        {'opacity': '1'}
-      ], this.timingFromConfig(config));
+      this._effect = new KeyframeEffect(
+          node,
+          [{'opacity': '1'}, {'opacity': '1'}],
+          this.timingFromConfig(config));
       node.style.opacity = '0';
       return this._effect;
     },
@@ -41,5 +38,4 @@ webkit/safari from drawing a frame before an animation for elements that animate
     }
 
   });
-
 </script>

--- a/animations/reverse-ripple-animation.html
+++ b/animations/reverse-ripple-animation.html
@@ -37,9 +37,7 @@ Configuration:
   Polymer({
     is: 'reverse-ripple-animation',
 
-    behaviors: [
-      Polymer.NeonSharedElementAnimationBehavior
-    ],
+    behaviors: [Polymer.NeonSharedElementAnimationBehavior],
 
     configure: function(config) {
       var shared = this.findSharedElements(config);
@@ -54,21 +52,28 @@ Configuration:
         translateY = config.gesture.y - (fromRect.top + (fromRect.height / 2));
       } else {
         var toRect = shared.to.getBoundingClientRect();
-        translateX = (toRect.left + (toRect.width / 2)) - (fromRect.left + (fromRect.width / 2));
-        translateY = (toRect.top + (toRect.height / 2)) - (fromRect.top + (fromRect.height / 2));
+        translateX = (toRect.left + (toRect.width / 2)) -
+            (fromRect.left + (fromRect.width / 2));
+        translateY = (toRect.top + (toRect.height / 2)) -
+            (fromRect.top + (fromRect.height / 2));
       }
       var translate = 'translate(' + translateX + 'px,' + translateY + 'px)';
 
-      var size = Math.max(fromRect.width + Math.abs(translateX) * 2, fromRect.height + Math.abs(translateY) * 2);
+      var size = Math.max(
+          fromRect.width + Math.abs(translateX) * 2,
+          fromRect.height + Math.abs(translateY) * 2);
       var diameter = Math.sqrt(2 * size * size);
       var scaleX = diameter / fromRect.width;
       var scaleY = diameter / fromRect.height;
       var scale = 'scale(' + scaleX + ',' + scaleY + ')';
 
-      this._effect = new KeyframeEffect(shared.from, [
-        {'transform': translate + ' ' + scale},
-        {'transform': translate + ' scale(0)'}
-      ], this.timingFromConfig(config));
+      this._effect = new KeyframeEffect(
+          shared.from,
+          [
+            {'transform': translate + ' ' + scale},
+            {'transform': translate + ' scale(0)'}
+          ],
+          this.timingFromConfig(config));
 
       this.setPrefixedProperty(shared.from, 'transformOrigin', '50% 50%');
       shared.from.style.borderRadius = '50%';

--- a/animations/ripple-animation.html
+++ b/animations/ripple-animation.html
@@ -36,14 +36,11 @@ Configuration:
 -->
 
 <script>
-
   Polymer({
 
     is: 'ripple-animation',
 
-    behaviors: [
-      Polymer.NeonSharedElementAnimationBehavior
-    ],
+    behaviors: [Polymer.NeonSharedElementAnimationBehavior],
 
     configure: function(config) {
       var shared = this.findSharedElements(config);
@@ -58,21 +55,28 @@ Configuration:
         translateY = config.gesture.y - (toRect.top + (toRect.height / 2));
       } else {
         var fromRect = shared.from.getBoundingClientRect();
-        translateX = (fromRect.left + (fromRect.width / 2)) - (toRect.left + (toRect.width / 2));
-        translateY = (fromRect.top + (fromRect.height / 2)) - (toRect.top + (toRect.height / 2));
+        translateX = (fromRect.left + (fromRect.width / 2)) -
+            (toRect.left + (toRect.width / 2));
+        translateY = (fromRect.top + (fromRect.height / 2)) -
+            (toRect.top + (toRect.height / 2));
       }
       var translate = 'translate(' + translateX + 'px,' + translateY + 'px)';
 
-      var size = Math.max(toRect.width + Math.abs(translateX) * 2, toRect.height + Math.abs(translateY) * 2);
+      var size = Math.max(
+          toRect.width + Math.abs(translateX) * 2,
+          toRect.height + Math.abs(translateY) * 2);
       var diameter = Math.sqrt(2 * size * size);
       var scaleX = diameter / toRect.width;
       var scaleY = diameter / toRect.height;
       var scale = 'scale(' + scaleX + ',' + scaleY + ')';
 
-      this._effect = new KeyframeEffect(shared.to, [
-        {'transform': translate + ' scale(0)'},
-        {'transform': translate + ' ' + scale}
-      ], this.timingFromConfig(config));
+      this._effect = new KeyframeEffect(
+          shared.to,
+          [
+            {'transform': translate + ' scale(0)'},
+            {'transform': translate + ' ' + scale}
+          ],
+          this.timingFromConfig(config));
 
       this.setPrefixedProperty(shared.to, 'transformOrigin', '50% 50%');
       shared.to.style.borderRadius = '50%';
@@ -88,5 +92,4 @@ Configuration:
     }
 
   });
-
 </script>

--- a/animations/scale-down-animation.html
+++ b/animations/scale-down-animation.html
@@ -28,14 +28,11 @@ Configuration:
 -->
 
 <script>
-
   Polymer({
 
     is: 'scale-down-animation',
 
-    behaviors: [
-      Polymer.NeonAnimationBehavior
-    ],
+    behaviors: [Polymer.NeonAnimationBehavior],
 
     configure: function(config) {
       var node = config.node;
@@ -47,10 +44,10 @@ Configuration:
         scaleProperty = 'scale(1, 0)';
       }
 
-      this._effect = new KeyframeEffect(node, [
-        {'transform': 'scale(1,1)'},
-        {'transform': scaleProperty}
-      ], this.timingFromConfig(config));
+      this._effect = new KeyframeEffect(
+          node,
+          [{'transform': 'scale(1,1)'}, {'transform': scaleProperty}],
+          this.timingFromConfig(config));
 
       if (config.transformOrigin) {
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
@@ -60,5 +57,4 @@ Configuration:
     }
 
   });
-
 </script>

--- a/animations/scale-up-animation.html
+++ b/animations/scale-up-animation.html
@@ -28,14 +28,11 @@ Configuration:
 -->
 
 <script>
-
   Polymer({
 
     is: 'scale-up-animation',
 
-    behaviors: [
-      Polymer.NeonAnimationBehavior
-    ],
+    behaviors: [Polymer.NeonAnimationBehavior],
 
     configure: function(config) {
       var node = config.node;
@@ -47,10 +44,10 @@ Configuration:
         scaleProperty = 'scale(1, 0)';
       }
 
-      this._effect = new KeyframeEffect(node, [
-        {'transform': scaleProperty},
-        {'transform': 'scale(1, 1)'}
-      ], this.timingFromConfig(config));
+      this._effect = new KeyframeEffect(
+          node,
+          [{'transform': scaleProperty}, {'transform': 'scale(1, 1)'}],
+          this.timingFromConfig(config));
 
       if (config.transformOrigin) {
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
@@ -60,5 +57,4 @@ Configuration:
     }
 
   });
-
 </script>

--- a/animations/slide-down-animation.html
+++ b/animations/slide-down-animation.html
@@ -27,22 +27,19 @@ Configuration:
 -->
 
 <script>
-
   Polymer({
 
     is: 'slide-down-animation',
 
-    behaviors: [
-      Polymer.NeonAnimationBehavior
-    ],
+    behaviors: [Polymer.NeonAnimationBehavior],
 
     configure: function(config) {
       var node = config.node;
 
-      this._effect = new KeyframeEffect(node, [
-        {'transform': 'translateY(0%)'},
-        {'transform': 'translateY(100%)'}
-      ], this.timingFromConfig(config));
+      this._effect = new KeyframeEffect(
+          node,
+          [{'transform': 'translateY(0%)'}, {'transform': 'translateY(100%)'}],
+          this.timingFromConfig(config));
 
       if (config.transformOrigin) {
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
@@ -54,5 +51,4 @@ Configuration:
     }
 
   });
-
 </script>

--- a/animations/slide-from-bottom-animation.html
+++ b/animations/slide-from-bottom-animation.html
@@ -27,22 +27,19 @@ Configuration:
 -->
 
 <script>
-
   Polymer({
 
     is: 'slide-from-bottom-animation',
 
-    behaviors: [
-      Polymer.NeonAnimationBehavior
-    ],
+    behaviors: [Polymer.NeonAnimationBehavior],
 
     configure: function(config) {
       var node = config.node;
 
-      this._effect = new KeyframeEffect(node, [
-        {'transform': 'translateY(100%)'},
-        {'transform': 'translateY(0)'}
-      ], this.timingFromConfig(config));
+      this._effect = new KeyframeEffect(
+          node,
+          [{'transform': 'translateY(100%)'}, {'transform': 'translateY(0)'}],
+          this.timingFromConfig(config));
 
       if (config.transformOrigin) {
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
@@ -54,5 +51,4 @@ Configuration:
     }
 
   });
-
 </script>

--- a/animations/slide-from-left-animation.html
+++ b/animations/slide-from-left-animation.html
@@ -28,22 +28,19 @@ Configuration:
 -->
 
 <script>
-
   Polymer({
 
     is: 'slide-from-left-animation',
 
-    behaviors: [
-      Polymer.NeonAnimationBehavior
-    ],
+    behaviors: [Polymer.NeonAnimationBehavior],
 
     configure: function(config) {
       var node = config.node;
 
-      this._effect = new KeyframeEffect(node, [
-        {'transform': 'translateX(-100%)'},
-        {'transform': 'none'}
-      ], this.timingFromConfig(config));
+      this._effect = new KeyframeEffect(
+          node,
+          [{'transform': 'translateX(-100%)'}, {'transform': 'none'}],
+          this.timingFromConfig(config));
 
       if (config.transformOrigin) {
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
@@ -55,5 +52,4 @@ Configuration:
     }
 
   });
-
 </script>

--- a/animations/slide-from-right-animation.html
+++ b/animations/slide-from-right-animation.html
@@ -28,22 +28,19 @@ Configuration:
 -->
 
 <script>
-
   Polymer({
 
     is: 'slide-from-right-animation',
 
-    behaviors: [
-      Polymer.NeonAnimationBehavior
-    ],
+    behaviors: [Polymer.NeonAnimationBehavior],
 
     configure: function(config) {
       var node = config.node;
 
-      this._effect = new KeyframeEffect(node, [
-        {'transform': 'translateX(100%)'},
-        {'transform': 'none'}
-      ], this.timingFromConfig(config));
+      this._effect = new KeyframeEffect(
+          node,
+          [{'transform': 'translateX(100%)'}, {'transform': 'none'}],
+          this.timingFromConfig(config));
 
       if (config.transformOrigin) {
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
@@ -55,5 +52,4 @@ Configuration:
     }
 
   });
-
 </script>

--- a/animations/slide-from-top-animation.html
+++ b/animations/slide-from-top-animation.html
@@ -27,22 +27,19 @@ Configuration:
 -->
 
 <script>
-
   Polymer({
 
     is: 'slide-from-top-animation',
 
-    behaviors: [
-      Polymer.NeonAnimationBehavior
-    ],
+    behaviors: [Polymer.NeonAnimationBehavior],
 
     configure: function(config) {
       var node = config.node;
 
-      this._effect = new KeyframeEffect(node, [
-        {'transform': 'translateY(-100%)'},
-        {'transform': 'translateY(0%)'}
-      ], this.timingFromConfig(config));
+      this._effect = new KeyframeEffect(
+          node,
+          [{'transform': 'translateY(-100%)'}, {'transform': 'translateY(0%)'}],
+          this.timingFromConfig(config));
 
       if (config.transformOrigin) {
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
@@ -54,5 +51,4 @@ Configuration:
     }
 
   });
-
 </script>

--- a/animations/slide-left-animation.html
+++ b/animations/slide-left-animation.html
@@ -27,22 +27,19 @@ Configuration:
 -->
 
 <script>
-
   Polymer({
 
     is: 'slide-left-animation',
 
-    behaviors: [
-      Polymer.NeonAnimationBehavior
-    ],
+    behaviors: [Polymer.NeonAnimationBehavior],
 
     configure: function(config) {
       var node = config.node;
 
-      this._effect = new KeyframeEffect(node, [
-        {'transform': 'none'},
-        {'transform': 'translateX(-100%)'}
-      ], this.timingFromConfig(config));
+      this._effect = new KeyframeEffect(
+          node,
+          [{'transform': 'none'}, {'transform': 'translateX(-100%)'}],
+          this.timingFromConfig(config));
 
       if (config.transformOrigin) {
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
@@ -54,5 +51,4 @@ Configuration:
     }
 
   });
-
 </script>

--- a/animations/slide-right-animation.html
+++ b/animations/slide-right-animation.html
@@ -27,22 +27,19 @@ Configuration:
 -->
 
 <script>
-
   Polymer({
 
     is: 'slide-right-animation',
 
-    behaviors: [
-      Polymer.NeonAnimationBehavior
-    ],
+    behaviors: [Polymer.NeonAnimationBehavior],
 
     configure: function(config) {
       var node = config.node;
 
-      this._effect = new KeyframeEffect(node, [
-        {'transform': 'none'},
-        {'transform': 'translateX(100%)'}
-      ], this.timingFromConfig(config));
+      this._effect = new KeyframeEffect(
+          node,
+          [{'transform': 'none'}, {'transform': 'translateX(100%)'}],
+          this.timingFromConfig(config));
 
       if (config.transformOrigin) {
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
@@ -54,5 +51,4 @@ Configuration:
     }
 
   });
-
 </script>

--- a/animations/slide-up-animation.html
+++ b/animations/slide-up-animation.html
@@ -27,22 +27,19 @@ Configuration:
 -->
 
 <script>
-
   Polymer({
 
     is: 'slide-up-animation',
 
-    behaviors: [
-      Polymer.NeonAnimationBehavior
-    ],
+    behaviors: [Polymer.NeonAnimationBehavior],
 
     configure: function(config) {
       var node = config.node;
 
-      this._effect = new KeyframeEffect(node, [
-        {'transform': 'translate(0)'},
-        {'transform': 'translateY(-100%)'}
-      ], this.timingFromConfig(config));
+      this._effect = new KeyframeEffect(
+          node,
+          [{'transform': 'translate(0)'}, {'transform': 'translateY(-100%)'}],
+          this.timingFromConfig(config));
 
       if (config.transformOrigin) {
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
@@ -54,5 +51,4 @@ Configuration:
     }
 
   });
-
 </script>

--- a/animations/transform-animation.html
+++ b/animations/transform-animation.html
@@ -29,14 +29,11 @@ Configuration:
 -->
 
 <script>
-
   Polymer({
 
     is: 'transform-animation',
 
-    behaviors: [
-      Polymer.NeonAnimationBehavior
-    ],
+    behaviors: [Polymer.NeonAnimationBehavior],
 
     /**
      * @param {{
@@ -52,10 +49,10 @@ Configuration:
       var transformFrom = config.transformFrom || 'none';
       var transformTo = config.transformTo || 'none';
 
-      this._effect = new KeyframeEffect(node, [
-        {'transform': transformFrom},
-        {'transform': transformTo}
-      ], this.timingFromConfig(config));
+      this._effect = new KeyframeEffect(
+          node,
+          [{'transform': transformFrom}, {'transform': transformTo}],
+          this.timingFromConfig(config));
 
       if (config.transformOrigin) {
         this.setPrefixedProperty(node, 'transformOrigin', config.transformOrigin);
@@ -65,5 +62,4 @@ Configuration:
     }
 
   });
-
 </script>

--- a/demo/card/index.html
+++ b/demo/card/index.html
@@ -167,7 +167,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       polymer1DomBindScope._onPolymerClick = polymer2DomBind._onPolymerClick;
       polymer1DomBindScope._onAngularClick = polymer2DomBind._onAngularClick;
       polymer1DomBindScope._onBackClick = polymer2DomBind._onBackClick;
-
     </script>
 
   </body>

--- a/demo/card/x-card.html
+++ b/demo/card/x-card.html
@@ -35,22 +35,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script>
-(function() {
+  (function() {
   Polymer({
     is: 'x-card',
 
-    behaviors: [
-      Polymer.NeonSharedElementAnimatableBehavior
-    ],
+    behaviors: [Polymer.NeonSharedElementAnimatableBehavior],
 
     properties: {
-      animationConfig: {
-        type: Object
-      },
+      animationConfig: {type: Object},
 
-      sharedElements: {
-        type: Object
-      }
+      sharedElements: {type: Object}
     },
 
     attached: function() {
@@ -59,35 +53,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       this.animationConfig = {
-        'entry': [{
-          name: 'ripple-animation',
-          id: 'ripple',
-          toPage: this
-        }, {
-          name: 'fade-out-animation',
-          node: this.$.placeholder,
-          timing: {
-            delay: 250
+        'entry': [
+          {name: 'ripple-animation', id: 'ripple', toPage: this},
+          {
+            name: 'fade-out-animation',
+            node: this.$.placeholder,
+            timing: {delay: 250}
+          },
+          {
+            name: 'fade-in-animation',
+            node: this.$.container,
+            timing: {delay: 50}
           }
-        }, {
-          name: 'fade-in-animation',
-          node: this.$.container,
-          timing: {
-            delay: 50
-          }
-        }],
+        ],
 
-        'exit': [{
-          name: 'fade-out-animation',
-          node: this.$.container,
-          timing: {
-            duration: 0
+        'exit': [
+          {
+            name: 'fade-out-animation',
+            node: this.$.container,
+            timing: {duration: 0}
+          },
+          {
+            name: 'reverse-ripple-animation',
+            id: 'reverse-ripple',
+            fromPage: this
           }
-        }, {
-          name: 'reverse-ripple-animation',
-          id: 'reverse-ripple',
-          fromPage: this
-        }]
+        ]
       };
 
       this.sharedElements = {
@@ -96,5 +87,5 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       };
     }
   });
-})();
+  })();
 </script>

--- a/demo/card/x-cards-list.html
+++ b/demo/card/x-cards-list.html
@@ -36,19 +36,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script>
-(function() {
+  (function() {
   Polymer({
     is: 'x-cards-list',
 
-    behaviors: [
-      Polymer.NeonSharedElementAnimatableBehavior
-    ],
+    behaviors: [Polymer.NeonSharedElementAnimatableBehavior],
 
-    properties: {
-      animationConfig: {
-        type: Object
-      }
-    },
+    properties: {animationConfig: {type: Object}},
 
     attached: function() {
       if (this.animationConfig) {
@@ -56,26 +50,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       this.animationConfig = {
-        'entry': [{
-          name: 'reverse-ripple-animation',
-          id: 'reverse-ripple',
-          toPage: this
-        }],
+        'entry': [
+          {name: 'reverse-ripple-animation', id: 'reverse-ripple', toPage: this}
+        ],
 
-        'exit': [{
-          name: 'fade-out-animation',
-          node: this.$.container,
-          timing: {
-            delay: 150,
-            duration: 0
-          }
-        }, {
-          name: 'ripple-animation',
-          id: 'ripple',
-          fromPage: this
-        }]
+        'exit': [
+          {
+            name: 'fade-out-animation',
+            node: this.$.container,
+            timing: {delay: 150, duration: 0}
+          },
+          {name: 'ripple-animation', id: 'ripple', fromPage: this}
+        ]
       };
     }
   });
-})();
+  })();
 </script>

--- a/demo/declarative/index.html
+++ b/demo/declarative/index.html
@@ -108,42 +108,44 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </dom-bind>
 
     <script>
-
       var scope1 = document.querySelector('template[is="dom-bind"]');
       var scope2 = document.querySelector('dom-bind');
 
       scope1.selected = 0;
       scope2.selected = 0;
 
-      scope1._onPrevClick = function() {
+      scope1._onPrevClick =
+          function() {
         this.entryAnimation = 'slide-from-left-animation';
         this.exitAnimation = 'slide-right-animation';
         this.selected = this.selected === 0 ? 4 : (this.selected - 1);
       }
 
-      scope1._onNextClick = function() {
+          scope1._onNextClick =
+              function() {
         this.entryAnimation = 'slide-from-right-animation';
         this.exitAnimation = 'slide-left-animation';
         this.selected = this.selected === 4 ? 0 : (this.selected + 1);
       }
 
-      scope1._onUpClick = function() {
+              scope1._onUpClick =
+                  function() {
         this.entryAnimation = 'slide-from-top-animation';
         this.exitAnimation = 'slide-down-animation';
         this.selected = this.selected === 4 ? 0 : (this.selected + 1);
       }
 
-      scope1._onDownClick = function() {
+                  scope1._onDownClick =
+                      function() {
         this.entryAnimation = 'slide-from-bottom-animation';
         this.exitAnimation = 'slide-up-animation';
         this.selected = this.selected === 0 ? 4 : (this.selected - 1);
       }
 
-      scope2._onPrevClick = scope1._onPrevClick;
+                      scope2._onPrevClick = scope1._onPrevClick;
       scope2._onNextClick = scope1._onNextClick;
       scope2._onUpClick = scope1._onUpClick;
       scope2._onDownClick = scope1._onDownClick;
-
     </script>
 
   </body>

--- a/demo/doc/index.html
+++ b/demo/doc/index.html
@@ -45,7 +45,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </dom-bind>
 
     <script>
-
       var scope1 = document.querySelector('template[is="dom-bind"]');
       var scope2 = document.querySelector('dom-bind');
 
@@ -67,9 +66,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       };
 
-     scope2._onCircleButtonClick = scope1._onCircleButtonClick;
-     scope2._onDialogButtonClick = scope1._onDialogButtonClick;
-
+      scope2._onCircleButtonClick = scope1._onCircleButtonClick;
+      scope2._onDialogButtonClick = scope1._onDialogButtonClick;
     </script>
 
   </body>

--- a/demo/doc/my-animatable.html
+++ b/demo/doc/my-animatable.html
@@ -28,14 +28,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script>
-
   Polymer({
 
     is: 'my-animatable',
 
-    behaviors: [
-      Polymer.NeonAnimationRunnerBehavior
-    ],
+    behaviors: [Polymer.NeonAnimationRunnerBehavior],
 
     properties: {
 
@@ -43,17 +40,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         type: Object,
         value: function() {
           return {
-            name: 'scale-down-animation',
-            node: this
+            name: 'scale-down-animation', node: this
           }
         }
       }
 
     },
 
-    listeners: {
-      'neon-animation-finish': '_onNeonAnimationFinish'
-    },
+    listeners: {'neon-animation-finish': '_onNeonAnimationFinish'},
 
     animate: function() {
       this.playAnimation();
@@ -64,5 +58,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
   });
-
 </script>

--- a/demo/doc/my-dialog.html
+++ b/demo/doc/my-dialog.html
@@ -35,42 +35,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script>
-
   Polymer({
 
     is: 'my-dialog',
 
-    behaviors: [
-      Polymer.NeonAnimationRunnerBehavior
-    ],
+    behaviors: [Polymer.NeonAnimationRunnerBehavior],
 
     properties: {
 
-      opened: {
-        type: Boolean
-      },
+      opened: {type: Boolean},
 
       animationConfig: {
         type: Object,
         value: function() {
           return {
-            'entry': [{
-              name: 'scale-up-animation',
-              node: this
-            }],
-            'exit': [{
-              name: 'fade-out-animation',
-              node: this
-            }]
+            'entry': [{name: 'scale-up-animation', node: this}],
+                'exit': [{name: 'fade-out-animation', node: this}]
           }
         }
       }
 
     },
 
-    listeners: {
-      'neon-animation-finish': '_onAnimationFinish'
-    },
+    listeners: {'neon-animation-finish': '_onAnimationFinish'},
 
     _onAnimationFinish: function() {
       if (!this.opened) {
@@ -90,5 +77,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
   });
-
 </script>

--- a/demo/dropdown/animated-dropdown.html
+++ b/demo/dropdown/animated-dropdown.html
@@ -28,14 +28,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script>
-
   Polymer({
 
     is: 'animated-dropdown',
 
-    behaviors: [
-      Polymer.NeonAnimationRunnerBehavior
-    ],
+    behaviors: [Polymer.NeonAnimationRunnerBehavior],
 
     properties: {
 
@@ -48,24 +45,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               node: this,
               transformOrigin: '0 0'
             }],
-            'exit': [{
-              name: 'fade-out-animation',
-              node: this
-            }]
+                'exit': [{name: 'fade-out-animation', node: this}]
           }
         }
       },
 
-      _showing: {
-        type: Boolean,
-        value: false
-      }
+      _showing: {type: Boolean, value: false}
 
     },
 
-    listeners: {
-      'neon-animation-finish': '_onAnimationFinish'
-    },
+    listeners: {'neon-animation-finish': '_onAnimationFinish'},
 
     _onAnimationFinish: function() {
       if (this._showing) {
@@ -86,5 +75,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
   });
-
 </script>

--- a/demo/dropdown/index.html
+++ b/demo/dropdown/index.html
@@ -37,12 +37,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </dom-bind>
 
     <script>
-
       var scope1 = document.querySelector('template[is="dom-bind"]');
       var scope2 = document.querySelector('dom-bind');
 
       scope1._onButtonClick = function(event) {
-        var dropdown = document.querySelector('#' + event.target.getAttribute('dropdown-id'));
+        var dropdown =
+            document.querySelector('#' + event.target.getAttribute('dropdown-id'));
         if (dropdown) {
           dropdown.show();
         }
@@ -54,7 +54,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       scope2._onButtonClick = scope1._onButtonClick;
       scope2._onDropdownClick = scope1._onDropdownClick;
-
     </script>
 
   </body>

--- a/demo/grid/animated-grid.html
+++ b/demo/grid/animated-grid.html
@@ -80,14 +80,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script>
-
   Polymer({
 
     is: 'animated-grid',
 
-    behaviors: [
-      Polymer.NeonSharedElementAnimatableBehavior
-    ],
+    behaviors: [Polymer.NeonSharedElementAnimatableBehavior],
 
     properties: {
 
@@ -113,15 +110,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         type: Object,
         value: function() {
           return {
-            'exit': [{
-              name: 'ripple-animation',
-              id: 'ripple',
-              fromPage: this
-            }, {
-              name: 'hero-animation',
-              id: 'hero',
-              fromPage: this
-            }]
+            'exit': [
+              {name: 'ripple-animation', id: 'ripple', fromPage: this},
+              {name: 'hero-animation', id: 'hero', fromPage: this}
+            ]
           }
         }
       }
@@ -140,21 +132,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       // configure the page animation
-      this.sharedElements = {
-        'hero': target,
-        'ripple': target
-      };
+      this.sharedElements = {'hero': target, 'ripple': target};
       this.animationConfig['exit'][0].gesture = {
         x: event.x || event.pageX,
         y: event.y || event.pageY
       };
 
-      this.fire('tile-click', {
-        tile: target,
-        data: target.item
-      });
+      this.fire('tile-click', {tile: target, data: target.item});
     }
 
   });
-
 </script>

--- a/demo/grid/fullsize-page-with-card.html
+++ b/demo/grid/fullsize-page-with-card.html
@@ -45,28 +45,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script>
-
   Polymer({
 
     is: 'fullsize-page-with-card',
 
-    behaviors: [
-      Polymer.NeonSharedElementAnimatableBehavior
-    ],
+    behaviors: [Polymer.NeonSharedElementAnimatableBehavior],
 
     properties: {
 
-      color: {
-        type: String
-      },
+      color: {type: String},
 
-      sharedElements: {
-        type: Object
-      },
+      sharedElements: {type: Object},
 
-      animationConfig: {
-        type: Object
-      }
+      animationConfig: {type: Object}
     },
 
     attached: function() {
@@ -74,33 +65,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return;
       }
 
-      this.sharedElements = {
-        'hero': this.$.card,
-        'ripple': this.$.fixed
-      };
+      this.sharedElements = {'hero': this.$.card, 'ripple': this.$.fixed};
 
       this.animationConfig = {
-        'entry': [{
-          name: 'ripple-animation',
-          id: 'ripple',
-          toPage: this,
-        }, {
-          name: 'hero-animation',
-          id: 'hero',
-          toPage: this,
-          timing: {
-            delay: 150
+        'entry': [
+          {
+            name: 'ripple-animation',
+            id: 'ripple',
+            toPage: this,
+          },
+          {
+            name: 'hero-animation',
+            id: 'hero',
+            toPage: this,
+            timing: {delay: 150}
           }
-        }],
-        'exit': [{
-          name: 'fade-out-animation',
-          node: this.$.fixed
-        }, {
-          name: 'transform-animation',
-          transformFrom: 'none',
-          transformTo: 'translate(0px,-200vh) scale(0.9,1)',
-          node: this.$.card
-        }]
+        ],
+        'exit': [
+          {name: 'fade-out-animation', node: this.$.fixed},
+          {
+            name: 'transform-animation',
+            transformFrom: 'none',
+            transformTo: 'translate(0px,-200vh) scale(0.9,1)',
+            node: this.$.card
+          }
+        ]
       };
     },
 
@@ -121,5 +110,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
   });
-
 </script>

--- a/demo/grid/index.html
+++ b/demo/grid/index.html
@@ -50,7 +50,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </dom-bind>
 
     <script>
-
       var scope1 = document.querySelector('template[is="dom-bind"]');
       var scope2 = document.querySelector('dom-bind');
 
@@ -67,7 +66,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       scope1._onFullsizeClick = _onFullsizeClick;
       scope2._onTileClick = _onTileClick;
       scope2._onFullsizeClick = _onFullsizeClick;
-
     </script>
 
   </body>

--- a/demo/list/full-view.html
+++ b/demo/list/full-view.html
@@ -66,24 +66,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script>
-
   Polymer({
 
     is: 'full-view',
 
-    behaviors: [
-      Polymer.NeonAnimatableBehavior
-    ],
+    behaviors: [Polymer.NeonAnimatableBehavior],
 
     properties: {
 
-      sharedElements: {
-        type: Object
-      },
+      sharedElements: {type: Object},
 
-      animationConfig: {
-        type: Object
-      }
+      animationConfig: {type: Object}
     },
 
     attached: function() {
@@ -91,27 +84,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return;
       }
 
-      this.sharedElements = { 'hero': this.$.main };
+      this.sharedElements = {'hero': this.$.main};
       this.animationConfig = {
-          'entry': [{
-            name: 'fade-in-animation',
-            node: this.$.button
-          }, {
-            name: 'hero-animation',
-            id: 'hero',
-            toPage: this
-          }],
+        'entry': [
+          {name: 'fade-in-animation', node: this.$.button},
+          {name: 'hero-animation', id: 'hero', toPage: this}
+        ],
 
-          'exit': [{
-            name: 'fade-out-animation',
-            node: this.$.button
-          }, {
+        'exit': [
+          {name: 'fade-out-animation', node: this.$.button},
+          {
             name: 'scale-down-animation',
             node: this.$.main,
             transformOrigin: '50% 50%',
             axis: 'y'
-          }]
-        }
+          }
+        ]
+      }
     },
 
     _onClearButtonClick: function() {
@@ -119,5 +108,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
   });
-
 </script>

--- a/demo/list/list-demo.html
+++ b/demo/list/list-demo.html
@@ -32,7 +32,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script>
-
   Polymer({
 
     is: 'list-demo',
@@ -97,5 +96,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
   });
-
 </script>

--- a/demo/list/list-view.html
+++ b/demo/list/list-view.html
@@ -64,18 +64,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script>
-
   Polymer({
 
     is: 'list-view',
 
-    behaviors: [
-      Polymer.NeonAnimatableBehavior
-    ],
+    behaviors: [Polymer.NeonAnimatableBehavior],
 
-    listeners: {
-      'click': '_onClick'
-    },
+    listeners: {'click': '_onClick'},
 
     properties: {
 
@@ -86,9 +81,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       },
 
-      animationConfig: {
-        type: Object
-      }
+      animationConfig: {type: Object}
     },
 
     attached: function() {
@@ -97,19 +90,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       this.animationConfig = {
-        'entry': [{
-          name: 'fade-in-animation',
-          node: this.$.button
-        }],
+        'entry': [{name: 'fade-in-animation', node: this.$.button}],
 
-        'exit': [{
-          name: 'fade-out-animation',
-          node: this.$.button
-        }, {
-          name: 'hero-animation',
-          id: 'hero',
-          fromPage: this
-        }]
+        'exit': [
+          {name: 'fade-out-animation', node: this.$.button},
+          {name: 'hero-animation', id: 'hero', fromPage: this}
+        ]
       };
     },
 
@@ -127,5 +113,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
   });
-
 </script>

--- a/demo/load/animated-grid.html
+++ b/demo/load/animated-grid.html
@@ -81,14 +81,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script>
-
   Polymer({
 
     is: 'animated-grid',
 
-    behaviors: [
-      Polymer.NeonSharedElementAnimatableBehavior
-    ],
+    behaviors: [Polymer.NeonSharedElementAnimatableBehavior],
 
     properties: {
 
@@ -119,9 +116,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               animation: 'transform-animation',
               transformFrom: 'translateY(100%)',
               transformTo: 'none',
-              timing: {
-                delay: 50
-              }
+              timing: {delay: 50}
             }]
           }
         }
@@ -132,7 +127,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     ready: function() {
       this.async(function() {
         var nodeList = Polymer.dom(this.root).querySelectorAll('.tile');
-        this.animationConfig['entry'][0].nodes = Array.prototype.slice.call(nodeList);
+        this.animationConfig['entry'][0].nodes =
+            Array.prototype.slice.call(nodeList);
       });
     },
 
@@ -141,5 +137,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
   });
-
 </script>

--- a/demo/load/full-page.html
+++ b/demo/load/full-page.html
@@ -43,40 +43,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script>
+  Polymer({
 
-Polymer({
+    is: 'full-page',
 
-  is: 'full-page',
+    behaviors:
+        [Polymer.NeonAnimatableBehavior, Polymer.NeonAnimationRunnerBehavior],
 
-  behaviors: [
-    Polymer.NeonAnimatableBehavior,
-    Polymer.NeonAnimationRunnerBehavior
-  ],
+    properties: {
 
-  properties: {
+      animationConfig: {type: Object}
+    },
 
-    animationConfig: {
-      type: Object
+    attached: function() {
+      this.animationConfig = this.animationConfig || {
+        'entry': [
+          {name: 'slide-from-top-animation', node: this.$.toolbar},
+          {animatable: this.$.grid, type: 'entry'}
+        ]
+      };
+    },
+
+    show: function() {
+      this.style.visibility = 'visible';
+      this.playAnimation('entry');
     }
-  },
 
-  attached: function() {
-    this.animationConfig = this.animationConfig || {
-      'entry': [{
-        name: 'slide-from-top-animation',
-        node: this.$.toolbar
-      }, {
-        animatable: this.$.grid,
-        type: 'entry'
-      }]
-    };
-  },
-
-  show: function() {
-    this.style.visibility = 'visible';
-    this.playAnimation('entry');
-  }
-
-});
-
+  });
 </script>

--- a/demo/load/index.html
+++ b/demo/load/index.html
@@ -40,11 +40,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <full-page></full-page>
 
     <script>
-
       window.addEventListener('WebComponentsReady', function() {
         document.querySelector('full-page').show();
       });
-
     </script>
 
   </body>

--- a/demo/tiles/circles-page.html
+++ b/demo/tiles/circles-page.html
@@ -42,25 +42,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script>
-
   Polymer({
 
     is: 'circles-page',
 
-    behaviors: [
-      Polymer.NeonSharedElementAnimatableBehavior
-    ],
+    behaviors: [Polymer.NeonSharedElementAnimatableBehavior],
 
     properties: {
 
-      animationConfig: {
-        type: Object
-      }
+      animationConfig: {type: Object}
     },
 
-    listeners: {
-      'click': '_onClick'
-    },
+    listeners: {'click': '_onClick'},
 
     attached: function() {
       if (this.animationConfig) {
@@ -76,14 +69,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           nodes: circlesArray
         }],
 
-        'exit': [{
-          name: 'hero-animation',
-          id: 'hero',
-          fromPage: this
-        }, {
-          name: 'cascaded-animation',
-          animation: 'scale-down-animation'
-        }]
+        'exit': [
+          {name: 'hero-animation', id: 'hero', fromPage: this},
+          {name: 'cascaded-animation', animation: 'scale-down-animation'}
+        ]
       };
     },
 
@@ -92,9 +81,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       if (target.classList.contains('circle')) {
         // configure the page animation
-        this.sharedElements = {
-          'hero': target
-        };
+        this.sharedElements = {'hero': target};
 
         var nodesToScale = [];
         var circles = Polymer.dom(this.root).querySelectorAll('.circle');
@@ -111,5 +98,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
   });
-
 </script>

--- a/demo/tiles/index.html
+++ b/demo/tiles/index.html
@@ -57,7 +57,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </dom-bind>
 
     <script>
-
       var scope1 = document.querySelector('template[is="dom-bind"]');
       var scope2 = document.querySelector('dom-bind');
 
@@ -73,7 +72,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       scope1._onSquaresClick = _onSquaresClick;
       scope2._onCircleClick = _onCircleClick;
       scope2._onSquaresClick = _onSquaresClick;
-
     </script>
 
   </body>

--- a/demo/tiles/squares-page.html
+++ b/demo/tiles/squares-page.html
@@ -46,24 +46,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script>
-
   Polymer({
 
     is: 'squares-page',
 
-    behaviors: [
-      Polymer.NeonSharedElementAnimatableBehavior
-    ],
+    behaviors: [Polymer.NeonSharedElementAnimatableBehavior],
 
     properties: {
 
-      sharedElements: {
-        type: Object
-      },
+      sharedElements: {type: Object},
 
-      animationConfig: {
-        type: Object
-      }
+      animationConfig: {type: Object}
     },
 
     attached: function() {
@@ -71,32 +64,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return;
       }
 
-      this.sharedElements = { 'hero': this.$.header };
+      this.sharedElements = {'hero': this.$.header};
       var squares = Polymer.dom(this.root).querySelectorAll('.square');
       var squaresArray = Array.prototype.slice.call(squares);
       this.animationConfig = {
-        'entry': [{
-          name: 'hero-animation',
-          id: 'hero',
-          toPage: this
-        }, {
-          name: 'cascaded-animation',
-          animation: 'transform-animation',
-          transformFrom: 'translateY(100%)',
-          nodes: squaresArray
-        }],
+        'entry': [
+          {name: 'hero-animation', id: 'hero', toPage: this},
+          {
+            name: 'cascaded-animation',
+            animation: 'transform-animation',
+            transformFrom: 'translateY(100%)',
+            nodes: squaresArray
+          }
+        ],
 
-        'exit': [{
-          name: 'slide-up-animation',
-          node: this.$.header
-        }, {
-          name: 'cascaded-animation',
-          animation: 'transform-animation',
-          transformTo: 'translateY(60vh)',
-          nodes: squaresArray
-        }]
+        'exit': [
+          {name: 'slide-up-animation', node: this.$.header},
+          {
+            name: 'cascaded-animation',
+            animation: 'transform-animation',
+            transformTo: 'translateY(60vh)',
+            nodes: squaresArray
+          }
+        ]
       };
     }
   });
-
 </script>

--- a/neon-animatable-behavior.d.ts
+++ b/neon-animatable-behavior.d.ts
@@ -13,8 +13,9 @@
 declare namespace Polymer {
 
   /**
-   * `Polymer.NeonAnimatableBehavior` is implemented by elements containing animations for use with
-   * elements implementing `Polymer.NeonAnimationRunnerBehavior`.
+   * `Polymer.NeonAnimatableBehavior` is implemented by elements containing
+   * animations for use with elements implementing
+   * `Polymer.NeonAnimationRunnerBehavior`.
    */
   interface NeonAnimatableBehavior {
 
@@ -24,14 +25,16 @@ declare namespace Polymer {
     animationConfig: object|null|undefined;
 
     /**
-     * Convenience property for setting an 'entry' animation. Do not set `animationConfig.entry`
-     * manually if using this. The animated node is set to `this` if using this property.
+     * Convenience property for setting an 'entry' animation. Do not set
+     * `animationConfig.entry` manually if using this. The animated node is set
+     * to `this` if using this property.
      */
     entryAnimation: string|null|undefined;
 
     /**
-     * Convenience property for setting an 'exit' animation. Do not set `animationConfig.exit`
-     * manually if using this. The animated node is set to `this` if using this property.
+     * Convenience property for setting an 'exit' animation. Do not set
+     * `animationConfig.exit` manually if using this. The animated node is set
+     * to `this` if using this property.
      */
     exitAnimation: string|null|undefined;
     _entryAnimationChanged(): void;
@@ -41,10 +44,11 @@ declare namespace Polymer {
     _getAnimationConfigRecursive(type: any, map: any, allConfigs: any): void;
 
     /**
-     * An element implementing `Polymer.NeonAnimationRunnerBehavior` calls this method to configure
-     * an animation with an optional type. Elements implementing `Polymer.NeonAnimatableBehavior`
-     * should define the property `animationConfig`, which is either a configuration object
-     * or a map of animation type to array of configuration objects.
+     * An element implementing `Polymer.NeonAnimationRunnerBehavior` calls this
+     * method to configure an animation with an optional type. Elements
+     * implementing `Polymer.NeonAnimatableBehavior` should define the property
+     * `animationConfig`, which is either a configuration object or a map of
+     * animation type to array of configuration objects.
      */
     getAnimationConfig(type: any): any;
   }

--- a/neon-animatable-behavior.html
+++ b/neon-animatable-behavior.html
@@ -11,10 +11,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 
 <script>
-
   /**
-   * `Polymer.NeonAnimatableBehavior` is implemented by elements containing animations for use with
-   * elements implementing `Polymer.NeonAnimationRunnerBehavior`.
+   * `Polymer.NeonAnimatableBehavior` is implemented by elements containing
+   * animations for use with elements implementing
+   * `Polymer.NeonAnimationRunnerBehavior`.
    * @polymerBehavior
    */
   Polymer.NeonAnimatableBehavior = {
@@ -24,44 +24,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * Animation configuration. See README for more info.
        */
-      animationConfig: {
-        type: Object
-      },
+      animationConfig: {type: Object},
 
       /**
-       * Convenience property for setting an 'entry' animation. Do not set `animationConfig.entry`
-       * manually if using this. The animated node is set to `this` if using this property.
+       * Convenience property for setting an 'entry' animation. Do not set
+       * `animationConfig.entry` manually if using this. The animated node is set
+       * to `this` if using this property.
        */
-      entryAnimation: {
-        observer: '_entryAnimationChanged',
-        type: String
-      },
+      entryAnimation: {observer: '_entryAnimationChanged', type: String},
 
       /**
-       * Convenience property for setting an 'exit' animation. Do not set `animationConfig.exit`
-       * manually if using this. The animated node is set to `this` if using this property.
+       * Convenience property for setting an 'exit' animation. Do not set
+       * `animationConfig.exit` manually if using this. The animated node is set
+       * to `this` if using this property.
        */
-      exitAnimation: {
-        observer: '_exitAnimationChanged',
-        type: String
-      }
+      exitAnimation: {observer: '_exitAnimationChanged', type: String}
 
     },
 
     _entryAnimationChanged: function() {
       this.animationConfig = this.animationConfig || {};
-      this.animationConfig['entry'] = [{
-        name: this.entryAnimation,
-        node: this
-      }];
+      this.animationConfig['entry'] = [{name: this.entryAnimation, node: this}];
     },
 
     _exitAnimationChanged: function() {
       this.animationConfig = this.animationConfig || {};
-      this.animationConfig['exit'] = [{
-        name: this.exitAnimation,
-        node: this
-      }];
+      this.animationConfig['exit'] = [{name: this.exitAnimation, node: this}];
     },
 
     _copyProperties: function(config1, config2) {
@@ -72,9 +60,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _cloneConfig: function(config) {
-      var clone = {
-        isClone: true
-      };
+      var clone = {isClone: true};
       this._copyProperties(clone, config);
       return clone;
     },
@@ -84,9 +70,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return;
       }
 
-      if(this.animationConfig.value && typeof this.animationConfig.value === 'function') {
-      	this._warn(this._logf('playAnimation', "Please put 'animationConfig' inside of your components 'properties' object instead of outside of it."));
-      	return;
+      if (this.animationConfig.value &&
+          typeof this.animationConfig.value === 'function') {
+        this._warn(this._logf(
+            'playAnimation',
+            'Please put \'animationConfig\' inside of your components \'properties\' object instead of outside of it.'));
+        return;
       }
 
       // type is optional
@@ -105,7 +94,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (thisConfig) {
         for (var config, index = 0; config = thisConfig[index]; index++) {
           if (config.animatable) {
-            config.animatable._getAnimationConfigRecursive(config.type || type, map, allConfigs);
+            config.animatable._getAnimationConfigRecursive(
+                config.type || type, map, allConfigs);
           } else {
             if (config.id) {
               var cachedConfig = map[config.id];
@@ -129,10 +119,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     /**
-     * An element implementing `Polymer.NeonAnimationRunnerBehavior` calls this method to configure
-     * an animation with an optional type. Elements implementing `Polymer.NeonAnimatableBehavior`
-     * should define the property `animationConfig`, which is either a configuration object
-     * or a map of animation type to array of configuration objects.
+     * An element implementing `Polymer.NeonAnimationRunnerBehavior` calls this
+     * method to configure an animation with an optional type. Elements
+     * implementing `Polymer.NeonAnimatableBehavior` should define the property
+     * `animationConfig`, which is either a configuration object or a map of
+     * animation type to array of configuration objects.
      */
     getAnimationConfig: function(type) {
       var map = {};
@@ -146,5 +137,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
   };
-
 </script>

--- a/neon-animatable.html
+++ b/neon-animatable.html
@@ -39,16 +39,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script>
-
   Polymer({
 
     is: 'neon-animatable',
 
-    behaviors: [
-      Polymer.NeonAnimatableBehavior,
-      Polymer.IronResizableBehavior
-    ]
+    behaviors: [Polymer.NeonAnimatableBehavior, Polymer.IronResizableBehavior]
 
   });
-
 </script>

--- a/neon-animated-pages.d.ts
+++ b/neon-animated-pages.d.ts
@@ -24,7 +24,7 @@ interface NeonAnimatedPagesElement extends Polymer.Element, Polymer.IronResizabl
   activateEvent: string|null|undefined;
 
   /**
-   * if true, the initial page selection will also be animated according to its animation config.
+   * its animation config.
    */
   animateInitialSelection: boolean|null|undefined;
   _onIronSelect(event: any): void;

--- a/neon-animated-pages.html
+++ b/neon-animated-pages.html
@@ -55,7 +55,7 @@ animations to be run when switching to or switching out of the page.
 </dom-module>
 
 <script>
-(function() {
+  (function() {
 
   Polymer({
 
@@ -69,16 +69,11 @@ animations to be run when switching to or switching out of the page.
 
     properties: {
 
-      activateEvent: {
-        type: String,
-        value: ''
-      },
+      activateEvent: {type: String, value: ''},
 
-      // if true, the initial page selection will also be animated according to its animation config.
-      animateInitialSelection: {
-        type: Boolean,
-        value: false
-      }
+      // if true, the initial page selection will also be animated according to
+      // its animation config.
+      animateInitialSelection: {type: Boolean, value: false}
 
     },
 
@@ -98,7 +93,8 @@ animations to be run when switching to or switching out of the page.
       var oldPage = this._valueToItem(this._prevSelected) || false;
       this._prevSelected = this.selected;
 
-      // on initial load and if animateInitialSelection is negated, simply display selectedPage.
+      // on initial load and if animateInitialSelection is negated, simply display
+      // selectedPage.
       if (!oldPage && !this.animateInitialSelection) {
         this._completeSelectedChanged();
         return;
@@ -108,22 +104,16 @@ animations to be run when switching to or switching out of the page.
 
       // configure selectedPage animations.
       if (this.entryAnimation) {
-        this.animationConfig.push({
-          name: this.entryAnimation,
-          node: selectedPage
-        });
+        this.animationConfig.push(
+            {name: this.entryAnimation, node: selectedPage});
       } else {
         if (selectedPage.getAnimationConfig) {
-          this.animationConfig.push({
-            animatable: selectedPage,
-            type: 'entry'
-          });
+          this.animationConfig.push({animatable: selectedPage, type: 'entry'});
         }
       }
 
       // configure oldPage animations iff exists.
       if (oldPage) {
-
         // cancel the currently running animation if one is ongoing.
         if (oldPage.classList.contains('neon-animating')) {
           this._squelchNextFinishEvent = true;
@@ -134,16 +124,10 @@ animations to be run when switching to or switching out of the page.
 
         // configure the animation.
         if (this.exitAnimation) {
-          this.animationConfig.push({
-            name: this.exitAnimation,
-            node: oldPage
-          });
+          this.animationConfig.push({name: this.exitAnimation, node: oldPage});
         } else {
           if (oldPage.getAnimationConfig) {
-            this.animationConfig.push({
-              animatable: oldPage,
-              type: 'exit'
-            });
+            this.animationConfig.push({animatable: oldPage, type: 'exit'});
           }
         }
 
@@ -156,21 +140,15 @@ animations to be run when switching to or switching out of the page.
 
       // actually run the animations.
       if (this.animationConfig.length >= 1) {
-
         // on first load, ensure we run animations only after element is attached.
         if (!this.isAttached) {
-          this.async(function () {
-            this.playAnimation(undefined, {
-              fromPage: null,
-              toPage: selectedPage
-            });
+          this.async(function() {
+            this.playAnimation(undefined, {fromPage: null, toPage: selectedPage});
           });
 
         } else {
-          this.playAnimation(undefined, {
-            fromPage: oldPage,
-            toPage: selectedPage
-          });
+          this.playAnimation(
+              undefined, {fromPage: oldPage, toPage: selectedPage});
         }
 
       } else {
@@ -214,6 +192,5 @@ animations to be run when switching to or switching out of the page.
       this.notifyResize();
     }
   })
-
-})();
+  })();
 </script>

--- a/neon-animation-behavior.d.ts
+++ b/neon-animation-behavior.d.ts
@@ -30,13 +30,14 @@ declare namespace Polymer {
     created(): void;
 
     /**
-     * Returns the animation timing by mixing in properties from `config` to the defaults defined
-     * by the animation.
+     * Returns the animation timing by mixing in properties from `config` to the
+     * defaults defined by the animation.
      */
     timingFromConfig(config: any): any;
 
     /**
-     * Sets `transform` and `transformOrigin` properties along with the prefixed versions.
+     * Sets `transform` and `transformOrigin` properties along with the prefixed
+     * versions.
      */
     setPrefixedProperty(node: any, property: any, value: any): void;
 

--- a/neon-animation-behavior.html
+++ b/neon-animation-behavior.html
@@ -11,7 +11,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 
 <script>
-
   /**
    * Use `Polymer.NeonAnimationBehavior` to implement an animation.
    * @polymerBehavior
@@ -27,9 +26,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         type: Object,
         value: function() {
           return {
-            duration: 500,
-            easing: 'cubic-bezier(0.4, 0, 0.2, 1)',
-            fill: 'both'
+            duration: 500, easing: 'cubic-bezier(0.4, 0, 0.2, 1)', fill: 'both'
           }
         }
       }
@@ -49,14 +46,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     created: function() {
       if (!document.body.animate) {
-        console.warn('No web animations detected. This element will not' +
+        console.warn(
+            'No web animations detected. This element will not' +
             ' function without a web animations polyfill.');
       }
     },
 
     /**
-     * Returns the animation timing by mixing in properties from `config` to the defaults defined
-     * by the animation.
+     * Returns the animation timing by mixing in properties from `config` to the
+     * defaults defined by the animation.
      */
     timingFromConfig: function(config) {
       if (config.timing) {
@@ -68,7 +66,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     /**
-     * Sets `transform` and `transformOrigin` properties along with the prefixed versions.
+     * Sets `transform` and `transformOrigin` properties along with the prefixed
+     * versions.
      */
     setPrefixedProperty: function(node, property, value) {
       var map = {
@@ -88,5 +87,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     complete: function(config) {}
 
   };
-
 </script>

--- a/neon-animation-runner-behavior.html
+++ b/neon-animation-runner-behavior.html
@@ -11,7 +11,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="neon-animatable-behavior.html">
 
 <script>
-
   /**
    * `Polymer.NeonAnimationRunnerBehavior` adds a method to run animations.
    *
@@ -29,8 +28,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // is this element actually a neon animation?
           if (neonAnimation.isNeonAnimation) {
             var result = null;
-            // Closure compiler does not work well with a try / catch here. .configure needs to be
-            // explicitly defined
+            // Closure compiler does not work well with a try / catch here.
+            // .configure needs to be explicitly defined
             if (!neonAnimation.configure) {
               /**
                * @param {Object} config
@@ -42,7 +41,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
 
             result = neonAnimation.configure(config);
-            resultsToPlay.push({ result: result, config: config });
+            resultsToPlay.push({result: result, config: config});
           } else {
             console.warn(this.is + ':', config.name, 'not found!');
           }
@@ -138,7 +137,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       for (var k in this._active) {
         var entries = this._active[k]
 
-        for (var j in entries) {
+                      for (var j in entries) {
           entries[j].animation.cancel();
         }
       }
@@ -148,8 +147,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   };
 
   /** @polymerBehavior Polymer.NeonAnimationRunnerBehavior */
-  Polymer.NeonAnimationRunnerBehavior = [
-    Polymer.NeonAnimatableBehavior,
-    Polymer.NeonAnimationRunnerBehaviorImpl
-  ];
+  Polymer.NeonAnimationRunnerBehavior =
+      [Polymer.NeonAnimatableBehavior, Polymer.NeonAnimationRunnerBehaviorImpl];
 </script>

--- a/neon-shared-element-animatable-behavior.d.ts
+++ b/neon-shared-element-animatable-behavior.d.ts
@@ -14,8 +14,8 @@
 declare namespace Polymer {
 
   /**
-   * Use `Polymer.NeonSharedElementAnimatableBehavior` to implement elements containing shared element
-   * animations.
+   * Use `Polymer.NeonSharedElementAnimatableBehavior` to implement elements
+   * containing shared element animations.
    */
   interface NeonSharedElementAnimatableBehavior extends Polymer.NeonAnimatableBehavior {
 

--- a/neon-shared-element-animatable-behavior.html
+++ b/neon-shared-element-animatable-behavior.html
@@ -12,10 +12,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="neon-animatable-behavior.html">
 
 <script>
-
   /**
-   * Use `Polymer.NeonSharedElementAnimatableBehavior` to implement elements containing shared element
-   * animations.
+   * Use `Polymer.NeonSharedElementAnimatableBehavior` to implement elements
+   * containing shared element animations.
    * @polymerBehavior Polymer.NeonSharedElementAnimatableBehavior
    */
   Polymer.NeonSharedElementAnimatableBehaviorImpl = {
@@ -25,10 +24,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * A map of shared element id to node.
        */
-      sharedElements: {
-        type: Object,
-        value: {}
-      }
+      sharedElements: {type: Object, value: {}}
 
     }
 
@@ -39,5 +35,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     Polymer.NeonAnimatableBehavior,
     Polymer.NeonSharedElementAnimatableBehaviorImpl
   ];
-
 </script>

--- a/neon-shared-element-animation-behavior.d.ts
+++ b/neon-shared-element-animation-behavior.d.ts
@@ -14,7 +14,8 @@
 declare namespace Polymer {
 
   /**
-   * Use `Polymer.NeonSharedElementAnimationBehavior` to implement shared element animations.
+   * Use `Polymer.NeonSharedElementAnimationBehavior` to implement shared element
+   * animations.
    */
   interface NeonSharedElementAnimationBehavior extends Polymer.NeonAnimationBehavior {
 

--- a/neon-shared-element-animation-behavior.html
+++ b/neon-shared-element-animation-behavior.html
@@ -12,9 +12,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="neon-animation-behavior.html">
 
 <script>
-
   /**
-   * Use `Polymer.NeonSharedElementAnimationBehavior` to implement shared element animations.
+   * Use `Polymer.NeonSharedElementAnimationBehavior` to implement shared element
+   * animations.
    * @polymerBehavior Polymer.NeonSharedElementAnimationBehavior
    */
   Polymer.NeonSharedElementAnimationBehaviorImpl = {
@@ -24,9 +24,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * Cached copy of shared elements.
        */
-      sharedElements: {
-        type: Object
-      }
+      sharedElements: {type: Object}
 
     },
 
@@ -37,12 +35,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var fromPage = config.fromPage;
       var toPage = config.toPage;
       if (!fromPage || !toPage) {
-        console.warn(this.is + ':', !fromPage ? 'fromPage' : 'toPage', 'is undefined!');
+        console.warn(
+            this.is + ':', !fromPage ? 'fromPage' : 'toPage', 'is undefined!');
         return null;
       };
 
       if (!fromPage.sharedElements || !toPage.sharedElements) {
-        console.warn(this.is + ':', 'sharedElements are undefined for', !fromPage.sharedElements ? fromPage : toPage);
+        console.warn(
+            this.is + ':',
+            'sharedElements are undefined for',
+            !fromPage.sharedElements ? fromPage : toPage);
         return null;
       };
 
@@ -50,14 +52,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var to = toPage.sharedElements[config.id];
 
       if (!from || !to) {
-        console.warn(this.is + ':', 'sharedElement with id', config.id, 'not found in', !from ? fromPage : toPage);
+        console.warn(
+            this.is + ':',
+            'sharedElement with id',
+            config.id,
+            'not found in',
+            !from ? fromPage : toPage);
         return null;
       }
 
-      this.sharedElements = {
-        from: from,
-        to: to
-      };
+      this.sharedElements = {from: from, to: to};
       return this.sharedElements;
     }
 
@@ -68,5 +72,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     Polymer.NeonAnimationBehavior,
     Polymer.NeonSharedElementAnimationBehaviorImpl
   ];
-
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,23 +3,34 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "1.0.1",
+        "glob-to-regexp": "0.3.0"
+      }
+    },
     "@polymer/gen-typescript-declarations": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-1.2.0.tgz",
-      "integrity": "sha512-a5DFXI3TdZSVOMH4608LVaBLmcr+mwM2+B8OSBiB9WFNCtdqzUXwtB5We6vBzrThXlO4uRo7d2pEqjNXMAlEkA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-1.2.2.tgz",
+      "integrity": "sha512-9P946+nIkSm+761v3oxH/QVgJozhsInldKY3h8AVstdXkA8W0Fij84pqsFv1nrRuPGj4Pv71crzoZpFnLkNmKQ==",
       "dev": true,
       "requires": {
         "@types/doctrine": "0.0.3",
-        "@types/fs-extra": "5.0.0",
+        "@types/fs-extra": "5.0.1",
         "@types/glob": "5.0.35",
         "command-line-args": "5.0.2",
-        "command-line-usage": "4.1.0",
+        "command-line-usage": "5.0.4",
         "doctrine": "2.1.0",
-        "escodegen": "1.9.0",
+        "escodegen": "1.9.1",
         "fs-extra": "5.0.0",
         "glob": "7.1.2",
         "minimatch": "3.0.4",
-        "polymer-analyzer": "3.0.0-pre.12"
+        "polymer-analyzer": "3.0.0-pre.14",
+        "vscode-uri": "1.0.3"
       }
     },
     "@types/babel-generator": {
@@ -95,18 +106,18 @@
       "dev": true
     },
     "@types/events": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
-      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
       "dev": true
     },
     "@types/fs-extra": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-qtxDULQKUenuaDLW003CgC+0T0eiAfH3BrH+vSt87GLzbz5EZ6Ox6mv9rMttvhDOatbb9nYh0E1m7ydoYwUrAg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.1.tgz",
+      "integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6"
+        "@types/node": "9.6.4"
       }
     },
     "@types/glob": {
@@ -115,10 +126,16 @@
       "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "dev": true,
       "requires": {
-        "@types/events": "1.1.0",
+        "@types/events": "1.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "9.4.6"
+        "@types/node": "9.6.4"
       }
+    },
+    "@types/is-windows": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@types/is-windows/-/is-windows-0.2.0.tgz",
+      "integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8=",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -127,9 +144,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.4.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
-      "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
+      "version": "9.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.4.tgz",
+      "integrity": "sha512-Awg4BcUYiZtNKoveGOu654JVPt11V/KIC77iBz8NweyoOAZpz5rUJfPDwwD+ajfTs2HndbTCEB8IuLfX9m/mmw==",
       "dev": true
     },
     "@types/parse5": {
@@ -138,25 +155,25 @@
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6"
+        "@types/node": "9.6.4"
+      }
+    },
+    "@types/resolve": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.6.tgz",
+      "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "9.6.4"
       }
     },
     "@types/winston": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.8.tgz",
-      "integrity": "sha512-QqR0j08RCS1AQYPMRPHikEpcmK+2aEEbcSzWLwOqyJ4FhLmHUx/WjRrnn7tTQg/y4IKnMhzskh/o7qvGIZZ7iA==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.9.tgz",
+      "integrity": "sha512-zzruYOEtNgfS3SBjcij1F6HlH6My5n8WrBNhP3fzaRM22ba70QBC2ATs18jGr88Fy43c0z8vFJv5wJankfxv2A==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6"
-      }
-    },
-    "ansi-escape-sequences": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
-      "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q==",
-      "dev": true,
-      "requires": {
-        "array-back": "2.0.0"
+        "@types/node": "9.6.4"
       }
     },
     "ansi-regex": {
@@ -166,10 +183,13 @@
       "dev": true
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "1.9.1"
+      }
     },
     "argv-tools": {
       "version": "0.1.1",
@@ -181,6 +201,24 @@
         "find-replace": "2.0.1"
       }
     },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
     "array-back": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
@@ -190,19 +228,37 @@
         "typical": "2.6.1"
       }
     },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
     "async": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
       "dev": true
     },
+    "atob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
+      "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
+      "dev": true
+    },
     "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.3.tgz",
+      "integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "chalk": "2.3.2",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
       }
@@ -221,6 +277,47 @@
         "lodash": "4.17.5",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "babel-types": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.5",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.3.tgz",
+      "integrity": "sha512-iMWYqwDarQOVlEGcK1MfbtK9vrFGs5Z4UQsdASJUHdhBp918EM5kndwriiIbhUX8gr2B/CEV/udJkFTrHsjdMQ==",
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "7.0.0-beta.3",
+        "babel-template": "7.0.0-beta.3",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.3.tgz",
+      "integrity": "sha512-ZkYFRMWKx1c9fUW72YNM3eieBG701CMbLjmLLWmJTTPc0F0kddS9Fwok26EAmndUAgD6kFdh7ms3PH94MdGuGQ==",
+      "dev": true,
+      "requires": {
+        "babel-types": "7.0.0-beta.3"
       }
     },
     "babel-messages": {
@@ -238,43 +335,78 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.5",
         "regenerator-runtime": "0.11.1"
       }
     },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+    "babel-template": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.3.tgz",
+      "integrity": "sha512-urJduLja89kSDGqY8ryw8iIwQnMl30IvhMtMNmDD7vBX0l0oylaLgK+7df/9ODX9vR/PhXuif6HYl5HlzAKXMg==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
+        "babel-code-frame": "7.0.0-beta.3",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.27",
         "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.27",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
+          "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-traverse": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.3.tgz",
+      "integrity": "sha512-xyh/aPYuedMAfQlSj2kjHjsEmY5/Dpxs576L05DySAVMrV+ADX6l4mTOLysAEGwJfkePJlDLhFuS6SKaxv1V7w==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "7.0.0-beta.3",
+        "babel-helper-function-name": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.27",
+        "debug": "3.1.0",
+        "globals": "10.4.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.27",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
+          "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg==",
+          "dev": true
+        }
       }
     },
     "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.3.tgz",
+      "integrity": "sha512-36k8J+byAe181OmCMawGhw+DtKO7AwexPVtsPXoMfAkjtZgoCX3bEuHWfdE5sYxRM8dojvtG/+O08M0Z/YDC6w==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
         "lodash": "4.17.5",
-        "to-fast-properties": "1.0.3"
+        "to-fast-properties": "2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
       }
     },
     "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
       "dev": true
     },
     "balanced-match": {
@@ -283,10 +415,65 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
     "bower": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz",
-      "integrity": "sha1-rfU1KcjUrwLvJPuNU0HBQZ0z4vc=",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.4.tgz",
+      "integrity": "sha1-54dqB23rgTf30GUl3F6MZtuC8oo=",
       "dev": true
     },
     "brace-expansion": {
@@ -299,23 +486,157 @@
         "concat-map": "0.0.1"
       }
     },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.2",
+        "snapdragon": "0.8.2",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
+      }
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
+    "cancel-token": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/cancel-token/-/cancel-token-0.1.1.tgz",
+      "integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
+      "dev": true,
+      "requires": {
+        "@types/node": "4.2.23"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "4.2.23",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.23.tgz",
+          "integrity": "sha512-U6IchCNLRyswc9p6G6lxWlbE+KwAhZp6mGo6MD2yWpmFomhYmetK+c98OpKyvphNn04CU3aXeJrXdOqbXVTS/w==",
+          "dev": true
+        }
+      }
+    },
+    "chalk": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+      "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "supports-color": "5.3.0"
+      }
+    },
+    "clang-format": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.2.3.tgz",
+      "integrity": "sha512-x90Hac4ERacGDcZSvHKK58Ga0STuMD+Doi5g0iG2zf7wlJef5Huvhs/3BvMRFxwRYyYSdl6mpQNrtfMxE8MQzw==",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "glob": "7.1.2",
+        "resolve": "1.7.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        }
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
       }
     },
     "clone": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "colors": {
@@ -338,16 +659,22 @@
       }
     },
     "command-line-usage": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
-      "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-h17lBwC5bl5RdukPbXji75+cg2/Qbny6kGsmLoy34s9DNH90RwRvJKb+VU5j4YY9HzYl7twLaOWDJQ4b9U+p/Q==",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "4.0.0",
         "array-back": "2.0.0",
-        "table-layout": "0.4.2",
+        "chalk": "2.3.2",
+        "table-layout": "0.4.3",
         "typical": "2.6.1"
       }
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -355,10 +682,16 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
     "core-js": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
       "dev": true
     },
     "cssbeautify": {
@@ -374,13 +707,19 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "deep-extend": {
       "version": "0.5.0",
@@ -393,6 +732,47 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
     },
     "detect-indent": {
       "version": "4.0.0",
@@ -419,7 +799,7 @@
       "dev": true,
       "requires": {
         "@types/parse5": "2.2.34",
-        "clone": "2.1.1",
+        "clone": "2.1.2",
         "parse5": "4.0.0"
       }
     },
@@ -430,16 +810,16 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+      "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "dev": true,
       "requires": {
         "esprima": "3.1.3",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "optionator": "0.8.2",
-        "source-map": "0.5.7"
+        "source-map": "0.6.1"
       }
     },
     "esprima": {
@@ -460,17 +840,183 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
     "eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
       "dev": true
     },
+    "fast-glob": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.0.tgz",
+      "integrity": "sha512-4F75PTznkNtSKs2pbhtBwRkw8sRwa7LfXx5XaQJOe4IQ6yTjceLDTwM5gj1s80R2t/5WeDC1gVfm3jLE+l39Tw==",
+      "dev": true,
+      "requires": {
+        "@mrmlnc/readdir-enhanced": "2.2.1",
+        "glob-parent": "3.1.0",
+        "is-glob": "4.0.0",
+        "merge2": "1.2.1",
+        "micromatch": "3.1.10"
+      }
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
     },
     "find-replace": {
       "version": "2.0.1",
@@ -480,6 +1026,21 @@
       "requires": {
         "array-back": "2.0.0",
         "test-value": "3.0.0"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "0.2.2"
       }
     },
     "fs-extra": {
@@ -499,6 +1060,12 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -513,10 +1080,37 @@
         "path-is-absolute": "1.0.1"
       }
     },
+    "glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "requires": {
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        }
+      }
+    },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
+    },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+      "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
       "dev": true
     },
     "graceful-fs": {
@@ -532,6 +1126,44 @@
       "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
       }
     },
     "indent": {
@@ -557,13 +1189,90 @@
       "dev": true
     },
     "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -573,6 +1282,79 @@
       "requires": {
         "number-is-nan": "1.0.1"
       }
+    },
+    "is-glob": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-odd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
@@ -602,9 +1384,15 @@
       }
     },
     "jsonschema": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
-      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
       "dev": true
     },
     "levn": {
@@ -635,6 +1423,12 @@
       "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
       "dev": true
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
@@ -642,6 +1436,48 @@
       "dev": true,
       "requires": {
         "js-tokens": "3.0.2"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "1.0.1"
+      }
+    },
+    "merge2": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.1.tgz",
+      "integrity": "sha512-wUqcG5pxrAcaFI1lkqkMnk3Q7nUxV/NWfpAFSeWUwG9TRODnBDCUHa75mi3o3vLWQ5N4CQERWCauSlP0I3ZqUg==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.2",
+        "nanomatch": "1.2.9",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "minimatch": {
@@ -662,17 +1498,107 @@
         "minimatch": "3.0.4"
       }
     },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "nanomatch": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -703,10 +1629,34 @@
       "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
       "dev": true
     },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
     "plylog": {
@@ -716,8 +1666,8 @@
       "dev": true,
       "requires": {
         "@types/node": "4.2.23",
-        "@types/winston": "2.3.8",
-        "winston": "2.4.0"
+        "@types/winston": "2.3.9",
+        "winston": "2.4.1"
       },
       "dependencies": {
         "@types/node": {
@@ -729,9 +1679,9 @@
       }
     },
     "polymer-analyzer": {
-      "version": "3.0.0-pre.12",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.12.tgz",
-      "integrity": "sha512-QQL70IC85hI6q9uQeresEMcT1Qf8YR/zDe1qG8WWeeFAZk8z0lmzUpsfcAWz+bM4wpDdXrtd4HitIs4p0CHl/w==",
+      "version": "3.0.0-pre.14",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.14.tgz",
+      "integrity": "sha512-1Zh/smUWMrjBB7NFUk8i7EAnjO81PqhI0/RzMMy9VgAbPQ6jOROwFX71T02CgpkZYa0O66Ybl7G3+4+0S1aF1Q==",
       "dev": true,
       "requires": {
         "@types/babel-generator": "6.25.1",
@@ -743,27 +1693,34 @@
         "@types/clone": "0.1.30",
         "@types/cssbeautify": "0.3.1",
         "@types/doctrine": "0.0.1",
+        "@types/is-windows": "0.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "6.0.101",
+        "@types/node": "6.0.105",
         "@types/parse5": "2.2.34",
+        "@types/resolve": "0.0.6",
         "babel-generator": "6.26.1",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.44",
+        "cancel-token": "0.1.1",
         "chalk": "1.1.3",
-        "clone": "2.1.1",
+        "clone": "2.1.2",
         "cssbeautify": "0.3.1",
         "doctrine": "2.1.0",
         "dom5": "3.0.0",
         "indent": "0.0.2",
-        "jsonschema": "1.2.2",
+        "is-windows": "1.0.2",
+        "jsonschema": "1.2.4",
         "minimatch": "3.0.4",
         "parse5": "4.0.0",
-        "polymer-project-config": "3.8.1",
+        "path-is-inside": "1.0.2",
+        "polymer-project-config": "3.13.0",
+        "resolve": "1.7.0",
         "shady-css-parser": "0.1.0",
         "stable": "0.1.6",
         "strip-indent": "2.0.0",
-        "vscode-uri": "1.0.1"
+        "vscode-uri": "1.0.3",
+        "whatwg-url": "6.4.0"
       },
       "dependencies": {
         "@types/doctrine": {
@@ -773,37 +1730,74 @@
           "dev": true
         },
         "@types/node": {
-          "version": "6.0.101",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.101.tgz",
-          "integrity": "sha512-IQ7V3D6+kK1DArTqTBrnl3M+YgJZLw8ta8w3Q9xjR79HaJzMAoTbZ8TNzUTztrkCKPTqIstE2exdbs1FzsYLUw==",
+          "version": "6.0.105",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.105.tgz",
+          "integrity": "sha512-fMIbw7iw91TSInS3b2DtDse5VaQEZqs0oTjvRNIFHnoHbnji+dLwpzL1L6dYGL39RzDNPHM/Off+VNcMk4ahwQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
     "polymer-project-config": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.8.1.tgz",
-      "integrity": "sha512-MLvnM9gexFWg7nynY24eHZG6NLXocmk718sVds/sx2CAJ6iihhC0JMhhOIa6jnad9KQrHyGl/cs3mMRaaub5Fg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.13.0.tgz",
+      "integrity": "sha512-0E1iSOpo2xFMvMomSDFl48J8IOUWmM+sfHGJSQSVfIu8GXDgz2TVraad+rEMZDbj8uxiRFvQZyouHhikxhVFpQ==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.101",
-        "jsonschema": "1.2.2",
+        "@types/node": "6.0.105",
+        "jsonschema": "1.2.4",
         "minimatch-all": "1.1.0",
         "plylog": "0.5.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.101",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.101.tgz",
-          "integrity": "sha512-IQ7V3D6+kK1DArTqTBrnl3M+YgJZLw8ta8w3Q9xjR79HaJzMAoTbZ8TNzUTztrkCKPTqIstE2exdbs1FzsYLUw==",
+          "version": "6.0.105",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.105.tgz",
+          "integrity": "sha512-fMIbw7iw91TSInS3b2DtDse5VaQEZqs0oTjvRNIFHnoHbnji+dLwpzL1L6dYGL39RzDNPHM/Off+VNcMk4ahwQ==",
           "dev": true
         }
       }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
       "dev": true
     },
     "reduce-flatten": {
@@ -818,6 +1812,28 @@
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
@@ -827,17 +1843,221 @@
         "is-finite": "1.0.2"
       }
     },
+    "resolve": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.0.tgz",
+      "integrity": "sha512-QdgZ5bjR1WAlpLaO5yHepFvC+o3rCr6wpfE2tpJNMkXdulf2jKomQBdNRQITF3ZKHNlT71syG98yQP03gasgnA==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "0.1.15"
+      }
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
     "shady-css-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
       "integrity": "sha512-irfJUUkEuDlNHKZNAp2r7zOyMlmbfVJ+kWSfjlCYYUx/7dJnANLCyTzQZsuxy5NJkvtNwSxY5Gj8MOlqXUQPyA==",
       "dev": true
     },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "optional": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+      "dev": true,
+      "requires": {
+        "atob": "2.1.0",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2"
+      }
     },
     "stable": {
       "version": "0.1.6",
@@ -850,6 +2070,27 @@
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -867,15 +2108,18 @@
       "dev": true
     },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+      "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+      "dev": true,
+      "requires": {
+        "has-flag": "3.0.0"
+      }
     },
     "table-layout": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.2.tgz",
-      "integrity": "sha512-tygyl5+eSHj4chpq5Zfy6cpc7MOUBClAW9ozghFH7hg9bAUzShOYn+/vUzTRkKOSLJWKfgYtP2tAU2c0oAD8eg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.3.tgz",
+      "integrity": "sha512-MIhflPM38ejKrFwWwC3P9x3eHvMo5G5AmNo29Qtz2HpBl5KD2GCcmOErjgNtUQLv/qaqVDagfJY3rJLPDvEgLg==",
       "dev": true,
       "requires": {
         "array-back": "2.0.0",
@@ -901,6 +2145,57 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.0"
+      }
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -922,22 +2217,141 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
       "dev": true
     },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
+          }
+        }
+      }
+    },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
       "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
       "dev": true
     },
-    "vscode-uri": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
-      "integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g=",
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "use": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+      "dev": true,
+      "requires": {
+        "kind-of": "6.0.2"
+      }
+    },
+    "vscode-uri": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.3.tgz",
+      "integrity": "sha1-Yxvb9xbcyrDmUpGo3CXCMjIIWlI=",
+      "dev": true
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "webmat": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/webmat/-/webmat-0.2.0.tgz",
+      "integrity": "sha512-xf2iHrssbbTofFwxvrdtgSxILQ8ledlpeDc76fNkTEL76gGnxCB/YA69UF498+UPfYIDvVnk9Qt2E7MJOApacA==",
+      "dev": true,
+      "requires": {
+        "clang-format": "1.2.3",
+        "dom5": "3.0.0",
+        "fast-glob": "2.2.0",
+        "parse5": "4.0.0"
+      }
+    },
+    "whatwg-url": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
+      }
+    },
     "winston": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
-      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.1.tgz",
+      "integrity": "sha512-k/+Dkzd39ZdyJHYkuaYmf4ff+7j+sCIy73UCOWHYA67/WXU+FF/Y6PF28j+Vy7qNRPHWO+dR+/+zkoQWPimPqg==",
       "dev": true,
       "requires": {
         "async": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
   "license": "BSD-3-Clause",
   "devDependencies": {
     "@polymer/gen-typescript-declarations": "^1.2.0",
-    "bower": "^1.8.0"
+    "bower": "^1.8.0",
+    "webmat": "^0.2.0"
   },
   "scripts": {
-    "update-types": "bower install && gen-typescript-declarations --deleteExisting --outDir ."
+    "update-types": "bower install && gen-typescript-declarations --deleteExisting --outDir .",
+    "format": "webmat && npm run update-types"
   }
 }

--- a/test/neon-animated-pages-descendant-selection.html
+++ b/test/neon-animated-pages-descendant-selection.html
@@ -69,13 +69,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
   window.addEventListener('WebComponentsReady', function() {
-    Polymer({ is: 'x-selecting-element' });
-    Polymer({ is: 'test-element' });
+    Polymer({is: 'x-selecting-element'});
+    Polymer({is: 'test-element'});
     Polymer({
       is: 'test-animation',
-      behaviors: [
-        Polymer.NeonAnimationBehavior
-      ],
+      behaviors: [Polymer.NeonAnimationBehavior],
       configure: function(config) {
         config.node.animated = true;
       }
@@ -93,32 +91,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </test-fixture>
 
 <script>
-suite('descendant selection', function() {
-  test('descendents of other selectors are not animated', function() {
-    var animatedPages = fixture('descendant-selection');
-    var selector = Polymer.dom(animatedPages).querySelector('#selector');
-    var target = Polymer.dom(animatedPages).querySelector('#target');
-    Polymer.dom(selector).setAttribute('selected', '1');
-    selector.forceSynchronousItemUpdate();
-    assert(!target.animated);
+  suite('descendant selection', function() {
+    test('descendents of other selectors are not animated', function() {
+      var animatedPages = fixture('descendant-selection');
+      var selector = Polymer.dom(animatedPages).querySelector('#selector');
+      var target = Polymer.dom(animatedPages).querySelector('#target');
+      Polymer.dom(selector).setAttribute('selected', '1');
+      selector.forceSynchronousItemUpdate();
+      assert(!target.animated);
+    });
+    test('elements distributed as children are animated', function() {
+      var testElement = fixture('distributed-children');
+      var target = Polymer.dom(testElement).querySelector('#target');
+      var animatedPages =
+          Polymer.dom(testElement.root).querySelector('neon-animated-pages');
+      Polymer.dom(animatedPages).setAttribute('selected', '1');
+      animatedPages.forceSynchronousItemUpdate();
+      assert(target.animated);
+    });
+    test('ignores selection from shadow descendants of its items', function() {
+      var pages = fixture('selecting-item');
+      var target = Polymer.dom(pages).querySelector('#target');
+      var selecting = Polymer.dom(pages).querySelector('x-selecting-element');
+      selecting.$.selector.selected = 1;
+      pages.forceSynchronousItemUpdate();
+      assert(!target.animated);
+    });
   });
-  test('elements distributed as children are animated', function() {
-    var testElement = fixture('distributed-children');
-    var target = Polymer.dom(testElement).querySelector('#target');
-    var animatedPages = Polymer.dom(testElement.root).querySelector("neon-animated-pages");
-    Polymer.dom(animatedPages).setAttribute('selected', '1');
-    animatedPages.forceSynchronousItemUpdate();
-    assert(target.animated);
-  });
-  test('ignores selection from shadow descendants of its items', function() {
-    var pages = fixture('selecting-item');
-    var target = Polymer.dom(pages).querySelector('#target');
-    var selecting = Polymer.dom(pages).querySelector('x-selecting-element');
-    selecting.$.selector.selected = 1;
-    pages.forceSynchronousItemUpdate();
-    assert(!target.animated);
-  });
-});
 </script>
 
 </body>

--- a/test/neon-animated-pages-lazy.html
+++ b/test/neon-animated-pages-lazy.html
@@ -19,7 +19,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
-  <script>Polymer = {lazyRegister: true}</script>
+  <script>
+    Polymer = {
+      lazyRegister: true
+    }
+  </script>
 
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../test-fixture/test-fixture-mocha.js"></script>
@@ -61,8 +65,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(event.detail.toPage, pages[1]);
           assert.isTrue(animatedPages._complete.calledTwice);
           var a$ = animatedPages._complete.getCall(1).args[0];
-          assert.isTrue(a$[0].neonAnimation.isNeonAnimation, 'entry animation is not a registered animation');
-          assert.isTrue(a$[1].neonAnimation.isNeonAnimation, 'exit animation is not a registered animation');
+          assert.isTrue(
+              a$[0].neonAnimation.isNeonAnimation,
+              'entry animation is not a registered animation');
+          assert.isTrue(
+              a$[1].neonAnimation.isNeonAnimation,
+              'exit animation is not a registered animation');
           done();
         });
         animatedPages.selected = 0;

--- a/test/neon-animated-pages.html
+++ b/test/neon-animated-pages.html
@@ -60,8 +60,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </test-fixture>
 
   <script>
-    suite('basic', function() {
-    });
+    suite('basic', function() {});
     suite('notify-resize', function() {
       test('only a destination page recieves a resize event', function(done) {
         var animatedPages = fixture('notify-resize');
@@ -76,26 +75,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         animatedPages.selected = 2;
         setTimeout(function() {
-          assert.deepEqual(recieves, {
-            'C-RESIZABLE-PAGE': 1
-          });
+          assert.deepEqual(recieves, {'C-RESIZABLE-PAGE': 1});
           done();
         }, 50);
       });
     });
     suite('animate-initial-selection', function() {
-      test('\'neon-animation-finish\' event fired after animating initial selection', function(done) {
-        var animatedPages = fixture('animate-initial-selection');
-        assert.isUndefined(animatedPages.selected);
-        var pages = Polymer.dom(animatedPages).children;
-        animatedPages.addEventListener('neon-animation-finish', function(event) {
-          assert.strictEqual(animatedPages.selected, 0);
-          assert.isFalse(event.detail.fromPage);
-          assert.deepEqual(event.detail.toPage, pages[0]);
-          done();
-        });
-        animatedPages.selected = 0;
-      });
+      test(
+          '\'neon-animation-finish\' event fired after animating initial selection',
+          function(done) {
+            var animatedPages = fixture('animate-initial-selection');
+            assert.isUndefined(animatedPages.selected);
+            var pages = Polymer.dom(animatedPages).children;
+            animatedPages.addEventListener(
+                'neon-animation-finish', function(event) {
+                  assert.strictEqual(animatedPages.selected, 0);
+                  assert.isFalse(event.detail.fromPage);
+                  assert.deepEqual(event.detail.toPage, pages[0]);
+                  done();
+                });
+            animatedPages.selected = 0;
+          });
     });
   </script>
 

--- a/test/test-resizable-pages.html
+++ b/test/test-resizable-pages.html
@@ -29,7 +29,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script>
-(function() {
+  (function() {
 
   Polymer({
     is: 'a-resizable-page',
@@ -54,6 +54,5 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       Polymer.IronResizableBehavior
     ]
   });
-
-})();
+  })();
 </script>


### PR DESCRIPTION
Runs the experimental autoformatter [webmat](https://github.com/PolymerLabs/webmat) which runs clang-format on js files and makes it so that it can run on HTML files. Please look through this PR with `?w=1` in the diff to make sure that no logic was changed.

What has changed?
You can run the formatter on the whole project by running `npm run format` and ex/include files from the formatter, and enter your custom clang-format config in a formatconfig.json see webmat readme for more!