### PR TITLE
Moved web-animations-js to dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "@polymer/iron-resizable-behavior": "^3.0.0-pre.1",
     "@polymer/iron-selector": "^3.0.0-pre.1",
-    "@polymer/polymer": "^3.0.0-pre.1"
+    "@polymer/polymer": "^3.0.0-pre.1",
+    "web-animations-js": "^2.3.1"
   },
   "devDependencies": {
     "@polymer/app-layout": "^3.0.0-pre.1",
@@ -32,7 +33,6 @@
     "@polymer/paper-item": "^3.0.0-pre.1",
     "@polymer/paper-styles": "^3.0.0-pre.1",
     "@polymer/test-fixture": "^3.0.0-pre.1",
-    "web-animations-js": "^2.3.1",
     "wct-browser-legacy": "0.0.1-pre.10",
     "@webcomponents/webcomponentsjs": "^1.0.0"
   }


### PR DESCRIPTION
Since `web-animations.html` has relative path to `web-animations-next-lite.min.js`, web-animations needs to be installed as dependency.
Otherwise components like `paper-dropdown-menu` doesn't work as they require `web-animations.html` and the relative path fails to get the file.