### PR TITLE
Explicitly set _template to null.

### DIFF
--- a/animations/cascaded-animation.js
+++ b/animations/cascaded-animation.js
@@ -29,6 +29,7 @@ Configuration:
 */
 Polymer({
   is: 'cascaded-animation',
+  _template: null,
 
   behaviors: [NeonAnimationBehavior],
 

--- a/animations/fade-in-animation.js
+++ b/animations/fade-in-animation.js
@@ -27,6 +27,7 @@ Configuration:
 Polymer({
 
   is: 'fade-in-animation',
+  _template: null,
 
   behaviors: [NeonAnimationBehavior],
 

--- a/animations/fade-out-animation.js
+++ b/animations/fade-out-animation.js
@@ -27,6 +27,7 @@ Configuration:
 Polymer({
 
   is: 'fade-out-animation',
+  _template: null,
 
   behaviors: [NeonAnimationBehavior],
 

--- a/animations/hero-animation.js
+++ b/animations/hero-animation.js
@@ -36,6 +36,7 @@ Configuration:
 Polymer({
 
   is: 'hero-animation',
+  _template: null,
 
   behaviors: [NeonSharedElementAnimationBehavior],
 

--- a/animations/opaque-animation.js
+++ b/animations/opaque-animation.js
@@ -20,6 +20,7 @@ animation for elements that animate from display:none.
 Polymer({
 
   is: 'opaque-animation',
+  _template: null,
 
   behaviors: [NeonAnimationBehavior],
 

--- a/animations/reverse-ripple-animation.js
+++ b/animations/reverse-ripple-animation.js
@@ -37,6 +37,7 @@ Configuration:
 */
 Polymer({
   is: 'reverse-ripple-animation',
+  _template: null,
 
   behaviors: [NeonSharedElementAnimationBehavior],
 

--- a/animations/ripple-animation.js
+++ b/animations/ripple-animation.js
@@ -39,6 +39,7 @@ Configuration:
 Polymer({
 
   is: 'ripple-animation',
+  _template: null,
 
   behaviors: [NeonSharedElementAnimationBehavior],
 

--- a/animations/scale-down-animation.js
+++ b/animations/scale-down-animation.js
@@ -30,6 +30,7 @@ Configuration:
 Polymer({
 
   is: 'scale-down-animation',
+  _template: null,
 
   behaviors: [NeonAnimationBehavior],
 

--- a/animations/scale-up-animation.js
+++ b/animations/scale-up-animation.js
@@ -30,6 +30,7 @@ Configuration:
 Polymer({
 
   is: 'scale-up-animation',
+  _template: null,
 
   behaviors: [NeonAnimationBehavior],
 

--- a/animations/slide-down-animation.js
+++ b/animations/slide-down-animation.js
@@ -29,6 +29,7 @@ Configuration:
 Polymer({
 
   is: 'slide-down-animation',
+  _template: null,
 
   behaviors: [NeonAnimationBehavior],
 

--- a/animations/slide-from-bottom-animation.js
+++ b/animations/slide-from-bottom-animation.js
@@ -28,6 +28,7 @@ Configuration:
 */
 Polymer({
   is: 'slide-from-bottom-animation',
+  _template: null,
 
   behaviors: [NeonAnimationBehavior],
 

--- a/animations/slide-from-left-animation.js
+++ b/animations/slide-from-left-animation.js
@@ -30,6 +30,7 @@ Configuration:
 Polymer({
 
   is: 'slide-from-left-animation',
+  _template: null,
 
   behaviors: [NeonAnimationBehavior],
 

--- a/animations/slide-from-right-animation.js
+++ b/animations/slide-from-right-animation.js
@@ -31,6 +31,7 @@ Configuration:
 Polymer({
 
   is: 'slide-from-right-animation',
+  _template: null,
 
   behaviors: [NeonAnimationBehavior],
 

--- a/animations/slide-from-top-animation.js
+++ b/animations/slide-from-top-animation.js
@@ -28,6 +28,7 @@ Configuration:
 */
 Polymer({
   is: 'slide-from-top-animation',
+  _template: null,
 
   behaviors: [NeonAnimationBehavior],
 

--- a/animations/slide-left-animation.js
+++ b/animations/slide-left-animation.js
@@ -28,6 +28,7 @@ Configuration:
 */
 Polymer({
   is: 'slide-left-animation',
+  _template: null,
 
   behaviors: [NeonAnimationBehavior],
 

--- a/animations/slide-right-animation.js
+++ b/animations/slide-right-animation.js
@@ -29,6 +29,7 @@ Configuration:
 Polymer({
 
   is: 'slide-right-animation',
+  _template: null,
 
   behaviors: [NeonAnimationBehavior],
 

--- a/animations/slide-up-animation.js
+++ b/animations/slide-up-animation.js
@@ -28,6 +28,7 @@ Configuration:
 */
 Polymer({
   is: 'slide-up-animation',
+  _template: null,
 
   behaviors: [NeonAnimationBehavior],
 

--- a/animations/transform-animation.js
+++ b/animations/transform-animation.js
@@ -30,6 +30,7 @@ Configuration:
 */
 Polymer({
   is: 'transform-animation',
+  _template: null,
 
   behaviors: [NeonAnimationBehavior],
 


### PR DESCRIPTION
This lets us skip a querySelector on initial bootup, and makes this code compatible with strictTemplatePolicy.

Internalized as part of cl/218551336